### PR TITLE
Use class names with package name when getting logger, instead of just using only the class name.

### DIFF
--- a/src/main/scala/api/api.scala
+++ b/src/main/scala/api/api.scala
@@ -60,7 +60,7 @@ class Failover[T](message: T, actorRef: ActorRef, strategy: FailoverStrategy)(ex
 }
 
 object Failover {
-  private val logger = LoggerFactory.getLogger("Failover")
+  private val logger = LoggerFactory.getLogger("reactivemongo.api.Failover")
   /**
    * Produces a [[reactivemongo.api.Failover]] holding a future reference that is completed with a result, after 1 or more attempts (specified in the given strategy).
    *

--- a/src/main/scala/api/bulk.scala
+++ b/src/main/scala/api/bulk.scala
@@ -12,7 +12,7 @@ import scala.concurrent.{ExecutionContext, Future}
  * Bulk insertion.
  */
 object bulk {
-  private val logger = LazyLogger(LoggerFactory.getLogger("Bulk"))
+  private val logger = LazyLogger(LoggerFactory.getLogger("reactivemongo.api.Bulk"))
   /** Default maximum size for a bulk (1MB). */
   val MaxBulkSize = 1024 * 1024
   /** Default maximum documents number for a bulk (100). */

--- a/src/main/scala/api/cursor.scala
+++ b/src/main/scala/api/cursor.scala
@@ -322,7 +322,7 @@ class TailableCursor[T](cursor: DefaultCursor[T], private val controller: Tailab
 object Cursor {
   import play.api.libs.iteratee._
 
-  private[api] val logger = LoggerFactory.getLogger("Cursor")
+  private[api] val logger = LoggerFactory.getLogger("reactivemongo.api.Cursor")
   
   /**
    * Flattens the given future [[reactivemongo.api.Cursor]] to a [[reactivemongo.api.FlattenedCursor]].

--- a/src/main/scala/api/gridfs.scala
+++ b/src/main/scala/api/gridfs.scala
@@ -93,7 +93,7 @@ case class DefaultReadFileEntry(
 ) extends ReadFileEntry
 
 object ReadFileEntry {
-  private val logger = LazyLogger(LoggerFactory.getLogger("ReadFileEntry"))
+  private val logger = LazyLogger(LoggerFactory.getLogger("reactivemongo.api.gridfs.ReadFileEntry"))
   // TODO
   def bsonReader(gFS: GridFS) = new Reader(gFS)
 
@@ -229,7 +229,7 @@ case class FileToWrite(
 }
 
 object FileToWrite {
-  private val logger = LazyLogger(LoggerFactory.getLogger("FileToWrite"))
+  private val logger = LazyLogger(LoggerFactory.getLogger("reactivemongo.api.gridfs.FileToWrite"))
 }
 
 /**

--- a/src/main/scala/core/actors.scala
+++ b/src/main/scala/core/actors.scala
@@ -375,7 +375,7 @@ class MongoDBSystem(
 
 object MongoDBSystem {
   private[reactivemongo] val DefaultConnectionRetryInterval :Int = 2000 // milliseconds
-  private val logger = LazyLogger(LoggerFactory.getLogger("MongoDBSystem"))
+  private val logger = LazyLogger(LoggerFactory.getLogger("reactivemongo.core.actors.MongoDBSystem"))
 }
 
 private[actors] case class AuthHistory(
@@ -469,7 +469,7 @@ class MonitorActor(sys: ActorRef) extends Actor {
 }
 
 object MonitorActor {
-  private val logger = LazyLogger(LoggerFactory.getLogger("MonitorActor"))
+  private val logger = LazyLogger(LoggerFactory.getLogger("reactivemongo.core.actors.MonitorActor"))
 }
 
 // exceptions

--- a/src/main/scala/core/nodeset.scala
+++ b/src/main/scala/core/nodeset.scala
@@ -39,7 +39,7 @@ case class MongoChannel(
 }
 
 object MongoChannel {
-  private val logger = LazyLogger(LoggerFactory.getLogger("NodeWrapper"))
+  private val logger = LazyLogger(LoggerFactory.getLogger("reactivemongo.core.nodeset.MongoChannel"))
   implicit def mongoChannelToChannel(mc: MongoChannel) :Channel = mc.channel
 }
 
@@ -184,7 +184,7 @@ class RoundRobiner[A](val subject: IndexedSeq[A], private var i: Int = 0) {
 case class LoggedIn(db: String, user: String)
 
 class ChannelFactory(bossExecutor: Executor = Executors.newCachedThreadPool, workerExecutor: Executor = Executors.newCachedThreadPool) {
-  private val logger = LazyLogger(LoggerFactory.getLogger("ChannelFactory"))
+  private val logger = LazyLogger(LoggerFactory.getLogger("reactivemongo.core.nodeset.ChannelFactory"))
 
   def create(host: String = "localhost", port: Int = 27017, receiver: ActorRef) = {
     val channel = makeChannel(receiver)

--- a/src/main/scala/core/protocol/protocol.scala
+++ b/src/main/scala/core/protocol/protocol.scala
@@ -225,7 +225,7 @@ private[reactivemongo] class RequestEncoder extends OneToOneEncoder {
 }
 
 private[reactivemongo] object RequestEncoder {
-  val logger = LazyLogger(LoggerFactory.getLogger("protocol/RequestEncoder"))
+  val logger = LazyLogger(LoggerFactory.getLogger("reactivemongo.core.protocol.RequestEncoder"))
 }
 
 private[reactivemongo] class ResponseFrameDecoder extends FrameDecoder {
@@ -292,7 +292,7 @@ private[reactivemongo] class MongoHandler(receiver: ActorRef) extends SimpleChan
 }
 
 private[reactivemongo] object MongoHandler {
-  private val logger = LazyLogger(LoggerFactory.getLogger("protocol/MongoHandler"))
+  private val logger = LazyLogger(LoggerFactory.getLogger("reactivemongo.core.protocol.MongoHandler"))
 }
 
 /**


### PR DESCRIPTION
Instead of just using the name of the class, it is better to use the full canonical name of the class. This allows filtering on the log level directly in the configuration of the used logging framework for all classes in ReactiveMongo, instead of having to do that for each class separately.
