### PR TITLE
Upgrade to 2.10 and quick compilation error fix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,4 +45,4 @@ publishMavenStyle := true
 
 sources in (Compile, doc) ~= (_ filter (p => !p.getAbsolutePath.contains("src/samples") && !p.getAbsolutePath.contains("src/main/scala/tests")))
 
-scalaVersion := "2.10.0-RC2"
+scalaVersion := "2.10.0"

--- a/src/main/scala/api/gridfs.scala
+++ b/src/main/scala/api/gridfs.scala
@@ -218,7 +218,7 @@ case class FileToWrite(
       }
     }
 
-    Iteratee.fold1(Chunk()) { (previous, chunk :Array[Byte]) =>
+    Iteratee.fold1(Future(Chunk())) { (previous, chunk :Array[Byte]) =>
       logger.debug("processing new enumerated chunk from n=" + previous.n + "...\n")
       previous.feed(chunk)
     }.mapDone(_.finish)


### PR DESCRIPTION
Simply changed SBT to use the release version of 2.10. Also, fixed a
compiler error in gridfs. Please review that using Future[Chunk] instead of Chunk() doesn't break anything.
