### PR TITLE
Add support for aggregation framework

### DIFF
--- a/src/main/scala/core/commands/aggregation.scala
+++ b/src/main/scala/core/commands/aggregation.scala
@@ -4,6 +4,13 @@ import reactivemongo.bson._
 import reactivemongo.bson.BSONString
 import reactivemongo.core.commands.{CommandError, BSONCommandResultMaker, Command}
 
+/**
+ * Implements the "aggregation" command, otherwise known as the "Aggregation Framework."
+ * http://docs.mongodb.org/manual/applications/aggregation/
+ *
+ * @param collectionName Collection to aggregate against
+ * @param pipeline Sequence of MongoDB aggregation operations.
+ */
 case class Aggregate (
   collectionName: String,
   pipeline: Seq[PipelineOperator]
@@ -24,32 +31,71 @@ object Aggregate extends BSONCommandResultMaker[BSONValue] {
     CommandError.checkOk(document, Some("aggregate")).toLeft(document.get("result").get)
 }
 
+/**
+ * One of MongoDBs pipeline operators for aggregation. Sealed as these are defined in
+ * the mongodb spec, and clients should not have custom operators.
+ */
 sealed trait PipelineOperator {
   def makePipe: BSONValue
 }
 
+/**
+ * Reshapes a document stream by renaming, adding, or removing fields.
+ * Also use "Project" to create computed values or sub-objects.
+ * NOTE: Currently only supports removing fields fields.
+ * http://docs.mongodb.org/manual/reference/aggregation/project/#_S_project
+ * @param fields Fields to include. The resulting objects will contain only these fields
+ */
 case class Project(fields: String*) extends PipelineOperator{
   override val makePipe = BSONDocument("$project" -> BSONDocument(
     {for (field <- fields) yield field -> BSONInteger(1)} : _*
   ))
 }
 
+/**
+ * Filters out documents from the stream that do not match the predicate.
+ * http://docs.mongodb.org/manual/reference/aggregation/match/#_S_match
+ * @param predicate Query that documents must satisfy to be in the stream.
+ */
 case class Match(predicate: BSONDocument) extends PipelineOperator{
   override val makePipe = BSONDocument("$match" -> predicate)
 }
 
+/**
+ * Limts the number of documents that pass through the stream.
+ * http://docs.mongodb.org/manual/reference/aggregation/limit/#_S_limit
+ * @param limit Number of documents to allow through.
+ */
 case class Limit(limit: Int) extends PipelineOperator{
   override val makePipe = BSONDocument("$limit" -> BSONInteger(limit))
 }
 
+/**
+ * Skips over a number of documents before passing all further documents along the stream.
+ * http://docs.mongodb.org/manual/reference/aggregation/skip/#_S_skip
+ * @param skip Number of documents to skip.
+ */
 case class Skip(skip: Int) extends PipelineOperator{
   override val makePipe = BSONDocument("$skip" -> BSONInteger(skip))
 }
 
+/**
+ * Turns a document with an array into multiple documents, one document for each
+ * element in the array.
+ * http://docs.mongodb.org/manual/reference/aggregation/unwind/#_S_unwind
+ * @param field Name of the array to unwind.
+ */
 case class Unwind(field: String) extends PipelineOperator{
   override val makePipe = BSONDocument("$unwind" -> BSONString("$" + field))
 }
 
+/**
+ * Groups documents together to calulate aggregates on document collections. This command
+ * aggregates on one field.
+ * http://docs.mongodb.org/manual/reference/aggregation/group/#_S_group
+ * @param idField Name of the field to aggregate on.
+ * @param ops Sequence of operators specifying aggregate calculation.
+ */
 case class GroupField(idField: String)(ops: (String, GroupFunction)*) extends PipelineOperator {
   override val makePipe = BSONDocument(
     "$group" -> BSONDocument(
@@ -61,6 +107,13 @@ case class GroupField(idField: String)(ops: (String, GroupFunction)*) extends Pi
   )
 }
 
+/**
+ * Groups documents together to calulate aggregates on document collections. This command
+ * aggregates on multiple fields, and they must be named.
+ * http://docs.mongodb.org/manual/reference/aggregation/group/#_S_group
+ * @param idField Fields to aggregate on, and the names they should be aggregated under.
+ * @param ops Sequence of operators specifying aggregate calculation.
+ */
 case class GroupMulti(idField: (String, String)*)(ops: (String, GroupFunction)*) extends PipelineOperator {
   override val makePipe = BSONDocument(
     "$group" -> BSONDocument(
@@ -76,6 +129,11 @@ case class GroupMulti(idField: (String, String)*)(ops: (String, GroupFunction)*)
   )
 }
 
+/**
+ * Sorts the stream based on the given fields.
+ * http://docs.mongodb.org/manual/reference/aggregation/sort/#_S_sort
+ * @param fields Fields to sort by.
+ */
 case class Sort(fields: Seq[SortOrder]) extends PipelineOperator{
   override val makePipe = BSONDocument("$sort" -> BSONDocument(fields.map{
     case Ascending(field) => field -> BSONInteger(1)
@@ -83,10 +141,18 @@ case class Sort(fields: Seq[SortOrder]) extends PipelineOperator{
   } : _*))
 }
 
+/**
+ * Represents that a field should be sorted on, as well as whether it
+ * should be ascending or descending.
+ */
 sealed trait SortOrder
 case class Ascending(field: String) extends SortOrder
 case class Descending(field: String) extends SortOrder
 
+/**
+ * Represents one of the group operators for the "Group" Operation. This class is sealed
+ * as these are defined in the MongoDB spec, and clients should not need to customise these.
+ */
 sealed trait GroupFunction {
   def makeFunction: BSONValue
 }


### PR DESCRIPTION
Idea for implementing the aggregation framework (#18) as a database command. Basic DSL contains operators used in the aggregation framework, allowing aggregation queries to be written in Scala. This command will return a regular BSONValue, to be parsed by json parsing library of choice. Each operator can create the BSON version of itself, and they are composed together to form the whole query. Example:

``` scala
val command = Aggregate("content", Seq(
        Project("keywords.text"),
        Unwind("keywords"),
        GroupField("keywords.text")("count" -> SumValue(1)),
        Match(BSONDocument("count" -> BSONDocument("$gte" -> BSONInteger(6000))))
      ))
```

will produce:

``` javascript
db.content.aggregate(
  {$project:{"keywords.text":1}},
  {$unwind:"$keywords"},
  {$group:{_id:"$keywords.text", cnt:{$sum:1}}},
  {$match:{"count":{$gt:1}}},
  {$sort:{"count":1}}
)
```

Open to suggestions on how to make the argument to the "Match" command suck less. Would probably require implementing most of the other database operators. Actually, if this method is accepted, my next project will probably be to implement all of the operators specified on [MongoDB's operator page](http://docs.mongodb.org/manual/reference/operator/) and use marker traits to organize them into groups (typeclasses??) specifying where they can and cannot be used (numeric comparator, aggregation operation, projection, etc.)
