### PR TITLE
Fixed off-by-one bug when reading a BSONBinary

### DIFF
--- a/bson/src/main/scala/buffer.scala
+++ b/bson/src/main/scala/buffer.scala
@@ -159,7 +159,7 @@ class ArrayReadableBuffer private (bytebuffer: ByteBuffer) extends ReadableBuffe
   def index = bytebuffer.position()
 
   def discard(n: Int) =
-    bytebuffer.position(bytebuffer.position() + n - 1)
+    bytebuffer.position(bytebuffer.position() + n)
 
   def slice(n: Int) = {
     val nb = bytebuffer.slice()

--- a/bson/src/main/scala/bufferhandlers.scala
+++ b/bson/src/main/scala/bufferhandlers.scala
@@ -101,7 +101,7 @@ object DefaultBufferHandler extends BufferHandler {
       val startIndex = b.index
       val length = b.readInt
       val buffer = b.slice(length - 4)
-      b.discard(length - 4 + 1)
+      b.discard(length - 4)
       def makeStream(): Stream[Try[(String, BSONValue)]] = {
         if (buffer.readable > 1) { // last is 0
           val code = buffer.readByte
@@ -132,7 +132,7 @@ object DefaultBufferHandler extends BufferHandler {
       val startIndex = b.index
       val length = b.readInt
       val buffer = b.slice(length - 4)
-      b.discard(length - 4 + 1)
+      b.discard(length - 4)
       def makeStream(): Stream[Try[BSONValue]] = {
         if (buffer.readable > 1) { // last is 0
           val code = buffer.readByte

--- a/driver/src/main/scala/core/netty.scala
+++ b/driver/src/main/scala/core/netty.scala
@@ -26,7 +26,7 @@ class ChannelBufferReadableBuffer(protected[netty] val buffer: ChannelBuffer) ex
   def index = buffer.readerIndex()
 
   def discard(n: Int) = {
-    buffer.readerIndex(buffer.readerIndex + n - 1)
+    buffer.readerIndex(buffer.readerIndex + n)
   }
 
   def slice(n: Int) = {


### PR DESCRIPTION
When reading a BSONBinary from a document, the readIndex is increased one too little. This causes that the next element won't be read correctly.

This is caused by discard increasing the index one too little. Other calls to discard add one to the parameter as a workaround to this bug, but it was easy to fix the root cause.
