### PR TITLE
Aggregation to return Stream[BSONDocument] instead of BSONValue

### DIFF
--- a/driver/src/main/scala/core/commands/aggregation.scala
+++ b/driver/src/main/scala/core/commands/aggregation.scala
@@ -37,13 +37,12 @@ sealed trait PipelineOperator {
 /**
  * Reshapes a document stream by renaming, adding, or removing fields.
  * Also use "Project" to create computed values or sub-objects.
- * NOTE: Currently only supports removing fields fields.
  * http://docs.mongodb.org/manual/reference/aggregation/project/#_S_project
  * @param fields Fields to include. The resulting objects will contain only these fields
  */
-case class Project(fields: String*) extends PipelineOperator {
+case class Project(fields: (String, Int)*) extends PipelineOperator {
   override val makePipe = BSONDocument("$project" -> BSONDocument(
-    { for (field <- fields) yield field -> BSONInteger(1) }.toStream))
+    { for (field <- fields) yield field._1 -> BSONInteger(field._2) }.toStream))
 }
 
 /**


### PR DESCRIPTION
Instead of returning BSONValue, or BSONArray, this returns a Stream of BSONDocument which the client can more readily work with.
