### PR TITLE
Allow bulkInsert with empty enumerator 

### DIFF
--- a/driver/src/test/scala/CommonUseCases.scala
+++ b/driver/src/test/scala/CommonUseCases.scala
@@ -21,6 +21,10 @@ class CommonUseCases extends Specification {
       val enum = Enumerator((18 to 60).map(i => BSONDocument("age" -> BSONInteger(i), "name" -> BSONString("Jack" + i))): _*)
       Await.result(collection.bulkInsert(enum, 100), timeout) mustEqual 43
     }
+    "insert from an empty enumerator of docs" in {
+      val enum = Enumerator[BSONDocument]()
+      Await.result(collection.bulkInsert(enum, 100), timeout) mustEqual 0
+    }
     "find them" in {
       // batchSize (>1) allows us to test cursors ;)
       val it = collection.find(BSONDocument()).options(QueryOpts().batchSize(2)).cursor


### PR DESCRIPTION
Allow bulkInsert with empty enumerator (see #76) and ensure that each bulk has at least one document to insert.

When the enumerator was empty or when the first document was larger than the maximum bulkByteSize then MongoDB returned the error DatabaseException['Message contains no documents' (code = 13066)]
