### PR TITLE
updated macros

### DIFF
--- a/macros/src/main/scala/interface.scala
+++ b/macros/src/main/scala/interface.scala
@@ -122,6 +122,10 @@ object Macros {
      * [[reactivemongo.bson.Macros.Options.SaveClassName]] in to ensure class
      * names are always serialized.
      *
+     * If there are handlers available in implicit scope for any of the types
+     * in the union they will be used to handle (de)serialization, otherwise
+     * handlers for all types will be generated.
+     *
      * Example
      * {{{
      * sealed trait Tree

--- a/macros/src/test/scala/macrospec.scala
+++ b/macros/src/test/scala/macrospec.scala
@@ -2,6 +2,8 @@ import reactivemongo.bson._
 import org.specs2.mutable._
 
 class Macros extends Specification {
+  type Handler[A] = BSONDocumentReader[A] with BSONDocumentWriter[A]  with BSONHandler[BSONDocument, A]
+
   def roundtrip[A](original: A, format: BSONReader[BSONDocument, A] with BSONWriter[A, BSONDocument]) = {
     val serialized = format write original
     val deserialized = format read serialized
@@ -45,8 +47,6 @@ class Macros extends Specification {
   }
 
   object TreeModule {
-    type Handler[A] = BSONDocumentReader[A] with BSONDocumentWriter[A]  with BSONHandler[BSONDocument, A]
-
     //due to compiler limitations(read: only workaround I found), handlers must be defined here
     //and explicit type annotations added to enable compiler to use implicit handlers recursively
 
@@ -57,6 +57,25 @@ class Macros extends Specification {
     object Tree {
       import Macros.Options._
       implicit val bson: Handler[Tree] = Macros.handlerOpts[Tree, UnionType[Node \/ Leaf]]
+    }
+  }
+
+  object TreeCustom{
+    sealed trait Tree
+    case class Node(left: Tree, right: Tree) extends Tree
+    case class Leaf(data: String) extends Tree
+
+    object Leaf {
+      private val helper = Macros.handler[Leaf]
+      implicit val bson: Handler[Leaf] = new BSONDocumentReader[Leaf] with BSONDocumentWriter[Leaf] with BSONHandler[BSONDocument, Leaf] {
+        def write(t: Leaf): BSONDocument = helper.write(Leaf("hai"))
+        def read(bson: BSONDocument): Leaf = helper read bson
+      }
+    }
+
+    object Tree {
+      import Macros.Options._
+      implicit val bson: Handler[Tree] = Macros.handlerOpts[Tree, UnionType[Node \/ Leaf] with Verbose]
     }
   }
 
@@ -74,7 +93,7 @@ class Macros extends Specification {
     }
 
     "support option" in {
-      val format = Macros.handlerOpts[Optional, Macros.Options.Verbose]
+      val format = Macros.handler[Optional]
       val some = Optional("some", Some("value"))
       val none = Optional("none", None)
       roundtrip(some, format)
@@ -155,6 +174,15 @@ class Macros extends Specification {
       //handlers defined at tree module
       val tree: Tree = Node(Leaf("hi"), Node(Leaf("hello"), Leaf("world")))
       roundtrip(tree, Tree.bson)
+    }
+
+    "grab an implicit handler for type used in union" in {
+      import TreeCustom._
+      val tree: Tree = Node(Leaf("hi"), Node(Leaf("hello"), Leaf("world")))
+      val serialized = BSON writeDocument tree
+      val deserialized = BSON.readDocument[Tree](serialized)
+      val expected = Node(Leaf("hai"), Node(Leaf("hai"),Leaf("hai")))
+      assert( deserialized === expected )
     }
   }
 }


### PR DESCRIPTION
I fixed a bug in union type parsing that prevented compilation in some cases(only when using this feature).

I also found a clean(ish) way do do recursive structures and have macros generate code for persisting them. This Solution is to put explicit type annotations on implicit handlers. This way compiler can know the types before running macros. So this means there are no cyclic dependencies between macros and stuff just works. And if you use is the "ADT pattern" then handler is just a oneliner that generates everything. 
This is now in documentation. Sample included.
