### PR TITLE
make ReactiveMongoException extend Exception instead of Throwable

### DIFF
--- a/driver/src/main/scala/core/errors.scala
+++ b/driver/src/main/scala/core/errors.scala
@@ -19,7 +19,7 @@ import reactivemongo.bson._
 import DefaultBSONHandlers._
 
 /** An error that can come from a MongoDB node or not. */
-trait ReactiveMongoException extends Throwable {
+trait ReactiveMongoException extends Exception {
   /** explanation message */
   val message: String
 


### PR DESCRIPTION
Not sure why it used to extend `Throwable`, but it made akka actor system stop on error.
