### PR TITLE
more macro magic

### DIFF
--- a/macros/src/main/scala/interface.scala
+++ b/macros/src/main/scala/interface.scala
@@ -152,5 +152,25 @@ object Macros {
      * `Foo \/ Bar \/ Baz` is interpreted as type Foo or type Bar or type Baz
      */
     trait \/[A, B]
+
+    /**
+     * Similar to [[reactivemongo.bson.Macros.Options.UnionType]] but finds all
+     * implementations of the top trait automatically. For this to be possible
+     * the top trait has to be sealed. If your tree is deeper(class extends trait
+     * that extends top trait) all the intermediate traits have to be sealed too!
+     *
+     * Example
+     * {{{
+     * sealed trait TopTrait
+     * case class OneImplementation(data: String) extends TopTrait
+     * case class SecondImplementation(data: Int) extends TopTrait
+     * sealed trait RefinedTrait extends TopTrait
+     * case class ThirdImplementation(data: Float, name: String) extends RefinedTrait
+     * case object StaticImplementation extends RefinedTrait
+     *
+     * val handler = Macros.handlerOpts[TopTrait, AllImplementations]
+     * }}}
+     */
+    trait AllImplementations extends SaveClassName with Default
   }
 }

--- a/macros/src/test/scala/macrospec.scala
+++ b/macros/src/test/scala/macrospec.scala
@@ -1,4 +1,3 @@
-import org.specs2.matcher.MatchResult
 import reactivemongo.bson._
 import org.specs2.mutable._
 
@@ -93,6 +92,14 @@ class Macros extends Specification {
       import Macros.Options._
       implicit val bson: Handler[IntList] = Macros.handlerOpts[IntList, UnionType[Cons \/ Tail.type]]
     }
+  }
+
+  object InheritanceModule {
+    sealed trait T
+    case class A() extends T
+    case object B extends T
+    sealed trait TT extends T
+    case class C() extends TT
   }
 
   "Formatter" should {
@@ -216,6 +223,25 @@ class Macros extends Specification {
       import IntListModule._
       roundtripImp[IntList](Tail)
       roundtripImp[IntList](Cons(1, Cons(2, Cons(3, Tail))))
+    }
+
+    "automate Union on sealed traits" in {
+      import Macros.Options._
+      import Union._
+      implicit val format = Macros.handlerOpts[UT, AllImplementations]
+      roundtripImp[UT](UA(17))
+      roundtripImp[UT](UB("foo"))
+      roundtripImp[UT](UC("bar"))
+      roundtripImp[UT](UD("baz"))
+    }
+
+    "support automatic implementations search with nested traits" in {
+      import Macros.Options._
+      import InheritanceModule._
+      implicit val format = Macros.handlerOpts[T, AllImplementations]
+      roundtripImp[T](A())
+      roundtripImp[T](B)
+      roundtripImp[T](C())
     }
   }
 }


### PR DESCRIPTION
Support for case classes without parameters and case objects. 
plus some additional boilerplate scraper in the form of AllImplementations that does the same as UnionType but without manually listing implementations(top trait has to be sealed).

note:
"Storing" singletons(object) is maybe not what you think. It just puts out an empty document. And reading returns the exisiting singleton. My reasoning is that there is no way to construct and replace the existing singleton so it's pointless to store anything. And global singletons should not expose any state anyway. This does work nicely when a singleton is just and implementation of a trait. This time the information "which implementation" is stored.
With addition of recursive structures you can have trees or lists with leafs/nil and no boilerplate to persist them.
