### PR TITLE
fixed unnecessary throwing of `DocumentKeyNotFound` exception

### DIFF
--- a/bson/src/main/scala/types.scala
+++ b/bson/src/main/scala/types.scala
@@ -49,11 +49,18 @@ case class BSONDocument(stream: Stream[Try[BSONElement]]) extends BSONValue {
    * If the key is not found or the matching value cannot be deserialized, returns a `Failure`.
    * The `Failure` holds a [[exceptions.DocumentKeyNotFound]] if the key could not be found.
    */
-  def getTry(key: String): Try[BSONValue] = Try {
-    stream.find {
-      case Success(element) => element._1 == key
-      case Failure(e)       => throw e
-    }.map(_.get._2).getOrElse(throw DocumentKeyNotFound(key))
+  def getTry(key: String): Try[BSONValue] = {
+    val tried = Try {
+      stream.find {
+        case Success(element) => element._1 == key
+        case Failure(e)       => throw e
+      }.map(_.get._2)
+    }
+    tried match {
+      case Success(Some(x)) => Success(x)
+      case Success(None)    => Failure(DocumentKeyNotFound(key))
+      case f: Failure[_]    => f.asInstanceOf[Try[BSONValue]]
+    }
   }
 
   /**


### PR DESCRIPTION
While profiling my app I saw a lot of exceptions thrown by reactivemongo, namely `DocumentKeyNotFound` and `ClassCastException` - actually I got **27500** `DocumentKeyNotFound`s and **10600** `ClassCastException`s in a very short period of time!

This pull request is a fix for the `DocumentKeyNotFound` exceptions. Instead of throwing it a `Failure` object will be created.