### PR TITLE
Fixes issue #78

### DIFF
--- a/driver/src/main/scala/core/commands/aggregation.scala
+++ b/driver/src/main/scala/core/commands/aggregation.scala
@@ -40,9 +40,10 @@ sealed trait PipelineOperator {
  * http://docs.mongodb.org/manual/reference/aggregation/project/#_S_project
  * @param fields Fields to include. The resulting objects will contain only these fields
  */
-case class Project(fields: (String, Int)*) extends PipelineOperator {
+case class Project(fields: (String, BSONValue)*) extends PipelineOperator {
   override val makePipe = BSONDocument("$project" -> BSONDocument(
-    { for (field <- fields) yield field._1 -> BSONInteger(field._2) }.toStream))
+    { for (field <- fields) yield field._1 -> field._2 }.toStream
+  ))
 }
 
 /**
@@ -91,7 +92,7 @@ case class Unwind(field: String) extends PipelineOperator {
  */
 case class GroupField(idField: String)(ops: (String, GroupFunction)*) extends PipelineOperator {
   override val makePipe = Group(BSONDocument(
-    "_id" -> BSONString("$" + idField) 
+    "_id" -> BSONString("$" + idField)
   ))(ops: _*).makePipe
 }
 


### PR DESCRIPTION
This pull request fixes issue https://github.com/ReactiveMongo/ReactiveMongo/issues/78 and it removes a single whitespace in the aggregation.scala file. It has small API changes, so it breaks backward compatibility.
