### PR TITLE
Network hardware address retrieval is now checked

### DIFF
--- a/bson/src/main/scala/types.scala
+++ b/bson/src/main/scala/types.scala
@@ -334,7 +334,7 @@ object BSONObjectID {
   private val machineId = {
     val networkInterfacesEnum = NetworkInterface.getNetworkInterfaces
     val networkInterfaces = scala.collection.JavaConverters.enumerationAsScalaIteratorConverter(networkInterfacesEnum).asScala
-    val ha = networkInterfaces.find(ha => ha.getHardwareAddress != null && ha.getHardwareAddress.length == 6)
+    val ha = networkInterfaces.find(ha => Try(ha.getHardwareAddress).isSuccess && ha.getHardwareAddress != null && ha.getHardwareAddress.length == 6)
       .map(_.getHardwareAddress)
       .getOrElse(InetAddress.getLocalHost.getHostName.getBytes)
     Converters.md5(ha).take(3)


### PR DESCRIPTION
In some Java security manager configurations, getting hardware address could fail during machine ID definition:

```
java.net.SocketException: No such device
    at reactivemongo.bson.BSONObjectID$.<init>(types.scala:337)
    at scala.collection.AbstractIterator.find(Iterator.scala:1157)
    at reactivemongo.bson.BSONObjectID$.<clinit>(types.scala)
    at scala.collection.Iterator$class.find(Iterator.scala:780)
    at reactivemongo.bson.BSONObjectID$$anonfun$1.apply(types.scala:337)
    at scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
    at reactivemongo.bson.BSONObjectID$$anonfun$1.apply(types.scala:337)
```

A try / catch has been added to the hardware address access.
