### PR TITLE
make macros-generated reader to throw meaningful exceptions instead of java.util.NoSuchElementException: None.get

### DIFF
--- a/macros/src/main/scala/macros.scala
+++ b/macros/src/main/scala/macros.scala
@@ -125,7 +125,7 @@ private object MacroImpl {
 
           val getter = Apply(
             TypeApply(
-              Select(Ident("document"), "getAs"),
+              Select(Ident("document"), "getAsTry"),
               List(TypeTree(typ))
 
             ),
@@ -133,7 +133,7 @@ private object MacroImpl {
           )
 
           if (optTyp.isDefined)
-            getter
+            Select(getter, "toOption")
           else
             Select(getter, "get")
       }


### PR DESCRIPTION
macros-generated reader throws `java.util.NoSuchElementException: None.get` exception if field can't be read for some reason. It makes debug much harder
