### PR TITLE
Implement MongoDB `eval` command

### DIFF
--- a/driver/src/main/scala/api/database.scala
+++ b/driver/src/main/scala/api/database.scala
@@ -117,6 +117,15 @@ trait DBMetaCommands {
       .cursor(collectionNameReader, ec)
       .collect[List]()
   }
+
+  /**
+   * Execute MongoDB eval command and return the result
+   * @param javascript javascript code for evaluation
+   * @param nolock donn't get global lock for the operation
+   * @param ec execution context
+   * @return operation result as BSONValue
+   */
+  def eval(javascript: String, nolock: Boolean)(implicit ec: ExecutionContext): Future[BSONValue] = command(new EvalCommnd(javascript, nolock))
 }
 
 /** The default DB implementation, that mixes in the database traits. */

--- a/driver/src/main/scala/core/commands/commands.scala
+++ b/driver/src/main/scala/core/commands/commands.scala
@@ -594,3 +594,17 @@ case class DeleteIndex(
     def apply(document: BSONDocument) =
       CommandError.checkOk(document, Some("deleteIndexes")).toLeft(document.getAs[BSONDouble]("nIndexesWas").map(_.value.toInt).get) }
 }
+
+/** eval command */
+case class EvalCommnd(
+    javascript: String,
+    nolock: Boolean) extends Command[Option[BSONValue]] {
+  override def makeDocuments = BSONDocument(
+    "eval" -> BSONString(javascript),
+    "nolock" -> BSONBoolean(nolock))
+
+  object ResultMaker extends BSONCommandResultMaker[Option[BSONValue]] {
+    def apply(document: BSONDocument) =
+      CommandError.checkOk(document, Some("eval")).toLeft(document.get("retval"))
+  }
+}

--- a/driver/src/test/scala/CommonUseCases.scala
+++ b/driver/src/test/scala/CommonUseCases.scala
@@ -81,5 +81,14 @@ class CommonUseCases extends Specification {
       Await.ready(future, timeout)
       (future.value.get match { case Failure(e) => e.printStackTrace(); true; case _ => false }) mustEqual true
     }
+    "eval custom javascript code" in {
+      val js = "return 1 === 1;"
+      val future = db.eval(js, nolock = false)
+
+      val result = Await.result(future, timeout)
+
+      println(BSONDocument.pretty(result))
+      result mustEqual BSONBoolean(true)
+    }
   }
 }


### PR DESCRIPTION
Implemented `eval` command support. 

http://docs.mongodb.org/manual/reference/command/eval/#dbcmd.eval
