### PR TITLE
add $ to AddToSet GroupFunction

### DIFF
--- a/driver/src/main/scala/core/commands/aggregation.scala
+++ b/driver/src/main/scala/core/commands/aggregation.scala
@@ -158,7 +158,7 @@ sealed trait GroupFunction {
 }
 
 case class AddToSet(field: String) extends GroupFunction {
-  def makeFunction = BSONDocument("$addToSet" -> BSONString(field))
+  def makeFunction = BSONDocument("$addToSet" -> BSONString("$" + field))
 }
 
 case class First(field: String) extends GroupFunction {


### PR DESCRIPTION
The AddToSet accepts a single string parameter which should be prefixed by the `$` sign 
Unless it takes a string and another function, then we don't have to prefix it
