### PR TITLE
Don't ignore writeConcern in BSONCollection.save

### DIFF
--- a/driver/src/main/scala/api/collections/bsoncollection.scala
+++ b/driver/src/main/scala/api/collections/bsoncollection.scala
@@ -135,8 +135,8 @@ case class BSONCollection(
    */
   def save(doc: BSONDocument, writeConcern: GetLastError)(implicit ec: ExecutionContext): Future[LastError] = {
     doc.get("_id").map { id =>
-      update(BSONDocument("_id" -> id), doc, upsert = true)
-    }.getOrElse(insert(doc.add("_id" -> BSONObjectID.generate)))
+      update(BSONDocument("_id" -> id), doc, writeConcern, upsert = true)
+    }.getOrElse(insert(doc.add("_id" -> BSONObjectID.generate)), writeConcern)
   }
 
   /**


### PR DESCRIPTION
The "save" helper, accepting a GetLastError as a parameter, invoked the
underlying GenericCollection.update and .insert without a writeConcern.
The default for the argument (GetLastError()) would then be used,
effectively ignoring the user provided writeConcern.

Refer to https://github.com/ReactiveMongo/ReactiveMongo/blob/master/driver/src/main/scala/api/collections/genericcollection.scala#L196-L203 and https://github.com/ReactiveMongo/ReactiveMongo/blob/master/driver/src/main/scala/api/collections/genericcollection.scala#L166-L171
