### PR TITLE
Fix for error propagation problem on enumerator created by cursor[T].enumerate()

### DIFF
--- a/driver/src/main/scala/core/iteratees.scala
+++ b/driver/src/main/scala/core/iteratees.scala
@@ -20,7 +20,7 @@ import play.api.libs.iteratee.Enumeratee.CheckDone
 import scala.concurrent._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{ Failure, Success }
-import scala.util.control.NonFatal
+import scala.util.control.NonFatal 
 
 object CustomEnumeratee {
   trait RecoverFromErrorFunction {


### PR DESCRIPTION
Let say we have a collection and we want to take some docs from it by applying an iteratee, we also want it to stop and return a failure future if there is an error, here is the code 

```
collection.find(query).sort(Json.obj(("title" -> 1))).cursor[JsObject]
        .enumerate(10,true).run(iteratee)
```

If an error occurs at the iteratee level the result of this code will hangs and the future will not complete at all.

This pull request solve the problem on Cursor.enumerate method to make the returned enumerator propagate the failure correctly.

I've already posted a question about this problem on http://stackoverflow.com/questions/24855594/reactivemongo-how-to-handle-an-exception-that-happens-inside-iteratee-fold
