### PR TITLE
Added @Ignore annotation for ignore fields on case classes

### DIFF
--- a/macros/src/main/scala/interface.scala
+++ b/macros/src/main/scala/interface.scala
@@ -196,5 +196,11 @@ object Macros {
      */
     @meta.param
     case class Key(key: String) extends StaticAnnotation
+    
+    /**
+     * Ignores a field
+     */
+    @meta.param
+    case class Ignore() extends StaticAnnotation
   }
 }


### PR DESCRIPTION
Earlier, to ignore a field, it should be type Option and have value None. The @Ignore annotation allows ignore a field of any type.
