### PR TITLE
Added implementation for @Ignore and scala's @transient annotation

### DIFF
--- a/macros/src/main/scala/macros.scala
+++ b/macros/src/main/scala/macros.scala
@@ -179,7 +179,7 @@ private object MacroImpl {
       val constructorParams = constructor.paramss.head
 
       val tuple = Ident(newTermName("tuple"))
-      val (optional, required) = constructorParams.zipWithIndex zip types partition (t => isOptionalType(t._2))
+      val (optional, required) = constructorParams.filter(p => !ignoreField(p)).zipWithIndex zip types partition (t => isOptionalType(t._2))
       val values = required map {
         case ((param, i), typ) => {
           val neededType = appliedType(writerType, List(typ))
@@ -325,6 +325,12 @@ private object MacroImpl {
             case value: String => value
           }
       }.flatten.headOption getOrElse param.name.toString
+    }
+    
+    private def ignoreField(param: c.Symbol): Boolean = {
+      param.annotations.collectFirst{
+        case ann => ann.tpe =:= typeOf[Ignore] || ann.tpe =:= typeOf[transient]
+      }.getOrElse(false)
     }
 
     private def allSubclasses(A: Symbol): Set[Symbol] = {


### PR DESCRIPTION
Earlier, to ignore a field, it should be type Option and have value None. The @Ignore annotation allows ignore a field of any type. The support for scala @transient was added as well.
