### PR TITLE
Fixes test on Windows OS

### DIFF
--- a/bson/src/test/scala/Handlers.scala
+++ b/bson/src/test/scala/Handlers.scala
@@ -188,9 +188,9 @@ class Handlers extends Specification {
       ]
     }
   ]
-}"""
+}""".replaceAll("\r", "")
       val ny2 = BSON.readDocument[Artist](doc)
-      val allSongs = doc.getAs[List[Album]]("albums").toList.flatten.flatMap(_.tracks)
+      val allSongs = doc.getAs[List[Album]]("albums").getOrElse(List.empty).flatMap(_.tracks)
       allSongs mustEqual List(
         "Cinnamon Girl",
         "Everybody Knows this is Nowhere",


### PR DESCRIPTION
Because of git checkout, the source code with """ multi-line string literals changes meaning :(

Also, the `.toList.flatten` construct was not understood by my IDE (intellij). I changed it to
`.getOrElse(List.empty)` because imho that is the nicest way to convert `Option[List[Album]]`
to `List[Album]`. Made intellij happy too :)