### PR TITLE
more efficient parsing of optional parameters (avoid unneeded throws)

### DIFF
--- a/macros/src/main/scala/macros.scala
+++ b/macros/src/main/scala/macros.scala
@@ -124,19 +124,27 @@ private object MacroImpl {
           val optTyp = optionTypeParameter(sig)
           val typ = optTyp getOrElse sig
 
-          val getter = Apply(
-            TypeApply(
-              Select(Ident("document"), "getAsTry"),
-              List(TypeTree(typ))
+          if (optTyp.isDefined) {
+            Apply(
+              TypeApply(
+                Select(Ident("document"), "getAs"),
+                List(TypeTree(typ))
+              ),
+              List(Literal(Constant(paramName(param))))
+            )
+          }
+          else {
+            val getter = Apply(
+              TypeApply(
+                Select(Ident("document"), "getAsTry"),
+                List(TypeTree(typ))
 
-            ),
-            List(Literal(Constant(paramName(param))))
-          )
-
-          if (optTyp.isDefined)
-            Select(getter, "toOption")
-          else
+              ),
+              List(Literal(Constant(paramName(param))))
+            )
             Select(getter, "get")
+          }
+
       }
 
       val constructorTree = Select(Ident(companion.name.toString), "apply")


### PR DESCRIPTION
Hi!

Our project uses data structures with a lot of optional fields (in form of Option[A]). When profiling it under load, I've noticed that JVM spends unusually high amount of CPU time (10-20%) in `Throwable.fillInStackTrace`.

![proof](https://cloud.githubusercontent.com/assets/954015/5374956/956ad9b6-806d-11e4-864e-0c6e7181b41b.PNG)

Further investigation showed that this is mostly called from `BSONDocument.getAsTry` from inside macro-generated parsers. While original reasoning behind this approach (_make macros-generated reader to throw meaningful exceptions instead of java.util.NoSuchElementException: None.get_) is solid, I believe in case of optional fields using `getAsTry...toOption` is unnecessary and only hurts performance. 

This commit changes parsing for optional fields back to simple `getAs`, while still keeping `getAsTry...get` path for non-optional fields.
