### PR TITLE
Fix Equality And Other Issues

### DIFF
--- a/bson/src/main/scala/buffer.scala
+++ b/bson/src/main/scala/buffer.scala
@@ -153,7 +153,7 @@ import java.nio.ByteBuffer
 import java.nio.ByteOrder._
 
 /** An array-backed readable buffer. */
-class ArrayReadableBuffer private (bytebuffer: ByteBuffer) extends ReadableBuffer {
+case class ArrayReadableBuffer private (bytebuffer: ByteBuffer) extends ReadableBuffer {
   bytebuffer.order(LITTLE_ENDIAN)
 
   def size = bytebuffer.limit()

--- a/bson/src/main/scala/bufferhandlers.scala
+++ b/bson/src/main/scala/bufferhandlers.scala
@@ -186,7 +186,7 @@ object DefaultBufferHandler extends BufferHandler {
     def read(buffer: ReadableBuffer) = BSONRegex(buffer.readCString, buffer.readCString)
   }
   object BSONDBPointerBufferHandler extends BufferRW[BSONDBPointer] {
-    def write(pointer: BSONDBPointer, buffer: WritableBuffer) = buffer // TODO
+    def write(pointer: BSONDBPointer, buffer: WritableBuffer) = { buffer writeCString pointer.value; buffer writeBytes pointer.id }
     def read(buffer: ReadableBuffer) = BSONDBPointer(buffer.readCString, buffer.readArray(12))
   }
   object BSONJavaScriptBufferHandler extends BufferRW[BSONJavaScript] {

--- a/bson/src/test/scala/Equality.scala
+++ b/bson/src/test/scala/Equality.scala
@@ -1,0 +1,94 @@
+import org.specs2.mutable._
+import reactivemongo.bson._
+import reactivemongo.bson.buffer.DefaultBufferHandler._
+import reactivemongo.bson.buffer.{ArrayReadableBuffer, DefaultBufferHandler, ArrayBSONBuffer}
+
+
+class Equality extends Specification {
+
+  "BSONDBPointer" should {
+    "permit equality to work" in {
+      val dbp1 = BSONDBPointer("coll", Array[Byte](1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))
+      val dbp2 = dbp1.copy()
+      dbp1 must beEqualTo(dbp2)
+    }
+    "retain equality through serialization/deserialization" in {
+      val dbp1 = BSONDBPointer("coll", Array[Byte](1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))
+      val writeBuffer = new ArrayBSONBuffer
+      BSONDBPointerBufferHandler.write(dbp1, writeBuffer)
+      val writeBytes = writeBuffer.array
+      val readBuffer = ArrayReadableBuffer(writeBytes)
+      val readBytes = readBuffer.slice(readBuffer.readable()).readArray(readBuffer.readable())
+      writeBytes must beEqualTo(readBytes)
+      val bdp2 = BSONDBPointerBufferHandler.read(readBuffer)
+      dbp1 must beEqualTo(bdp2)
+    }
+  }
+
+  "BSONObjectID" should {
+    "permit equality to work" in {
+      val boid1 = BSONObjectID("0102030405060708090a0b0c")
+      val boid2 = BSONObjectID("0102030405060708090a0b0c")
+      boid1 must beEqualTo(boid2)
+    }
+    "retain equality through serialization/deserialization" in {
+      val boid1 = BSONObjectID("0102030405060708090a0b0c")
+      val writeBuffer = new ArrayBSONBuffer
+      BSONObjectIDBufferHandler.write(boid1, writeBuffer)
+      val writeBytes = writeBuffer.array
+      val readBuffer = ArrayReadableBuffer(writeBytes)
+      val readBytes = readBuffer.slice(readBuffer.readable()).readArray(readBuffer.size)
+      writeBytes must beEqualTo(readBytes)
+      val boid2 = BSONObjectIDBufferHandler.read(readBuffer)
+      boid1 must beEqualTo(boid2)
+    }
+  }
+
+  "BSONArray" should {
+    "permit equality to work" in {
+      val ba1 = BSONArray(Seq(BSONInteger(42), BSONString("42"), BSONDouble(42.0), BSONDateTime(0)))
+      val ba2 = ba1.copy()
+      ba1 must beEqualTo(ba2)
+    }
+    "retain equality through serialization/deserialization" in {
+      val ba1 = BSONArray(Seq(BSONInteger(42), BSONString("42"), BSONDouble(42.0), BSONDateTime(0)))
+      val writeBuffer = new ArrayBSONBuffer
+      BSONArrayBufferHandler.write(ba1, writeBuffer)
+      val writeBytes = writeBuffer.array
+      val readBuffer = ArrayReadableBuffer(writeBytes)
+      val readBytes = readBuffer.slice(readBuffer.readable()).readArray(readBuffer.size)
+      writeBytes must beEqualTo(readBytes)
+      val ba2 = BSONArrayBufferHandler.read(readBuffer)
+      ba1 must beEqualTo(ba2)
+    }
+  }
+
+  "BSONDocument" should {
+    "retain equality through serialization/deserialization" in {
+      val b1 = BSONDocument(Seq(
+        "boolean" → BSONBoolean(value=true),
+        "int" → BSONInteger(42),
+        "long" → BSONLong(42L),
+        "double" → BSONDouble(42.0),
+        "string" → BSONString("forty-two"),
+        "datetime" → BSONDateTime(System.currentTimeMillis()),
+        "timestamp" → BSONTimestamp(System.currentTimeMillis()),
+        "binary" → BSONBinary(Array[Byte](1,2,3), Subtype.GenericBinarySubtype),
+        "objectid" → BSONObjectID(Array[Byte](1,2,3,4,5,6,7,8,9,10,11,12)),
+        "dbpointer" → BSONDBPointer("coll", Array[Byte](1,2,3,4,5,6,7,8,9,10,11,12)),
+        "array" → BSONArray(Seq(BSONInteger(42), BSONString("42"), BSONDouble(42.0), BSONDateTime(0)))
+      ))
+      val writeBuffer = new ArrayBSONBuffer
+      DefaultBufferHandler.write(writeBuffer, b1)
+      val writeBytes = writeBuffer.array
+      val readBuffer = ArrayReadableBuffer(writeBytes)
+      val readBytes = readBuffer.slice(readBuffer.readable()).readArray(readBuffer.size)
+      writeBytes must beEqualTo(readBytes)
+      val result = DefaultBufferHandler.readDocument(readBuffer)
+      result.isSuccess must beTrue
+      val b2 = result.get
+      b1 must beEqualTo(b2)
+    }
+  }
+
+}


### PR DESCRIPTION
This patch adds a test suite for testing equality of BSON classes including after serialization/deserialization. The idea is that the objects should be reflective after storage in the db and later materialized back again. Before this patch, this wasn't true. 

* Implement BSONDBPointerBufferHandler.write
* Make ArrayReadableBuffer a case class to get properly constructed .canEqual and .equals methods to avoid false negatives
* Fix misleading comments in BSONArray
* Fix misleading toString method in BSONArray (reported it was a BSONDocument)
* Make BSONObjectID extend Equals and implement canEqual and equals for it, properly (gave false negatives previously)
* Make BSONDBPointer override equals and canEqual to avoid false negatives
* Add an Equality test suite to validate that the above all works.

