### PR TITLE
Modernize SBT Dependency Versions

### DIFF
--- a/project/ReactiveMongo.scala
+++ b/project/ReactiveMongo.scala
@@ -1,5 +1,6 @@
 import sbt._
 import sbt.Keys._
+import scala.language.postfixOps
 
 object BuildSettings {
   val buildVersion = "0.11.0-SNAPSHOT"
@@ -11,7 +12,7 @@ object BuildSettings {
     }
   }
 
-  val buildSettings = Defaults.defaultSettings ++ Seq(
+  val buildSettings = Defaults.coreDefaultSettings ++ Seq(
     organization := "org.reactivemongo",
     version := buildVersion,
     scalaVersion := "2.11.2",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,9 @@
-scalacOptions ++= Seq("-deprecation", "-unchecked")
+scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.2.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
 
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.4")
 
-addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.0")
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.1")


### PR DESCRIPTION
* SBT 0.13.7 => 0.13.7 - Faster dependency resolution
* Add -feature compile option to get feature warnings
* sbt-scaliariform 1.2.1 => 1.3.0
* sbt-git 0.6.2 => 0.6.4
* sbt-unidoc 0.3.0 => 0.3.1
* Fix deprecation warning in ReactiveMongo.scala: Defaults.defaultSettings => Defaults.coreDefaultSettings