### PR TITLE
Minimize warnings

### DIFF
--- a/bson/src/main/scala/bson.scala
+++ b/bson/src/main/scala/bson.scala
@@ -15,6 +15,8 @@
  */
 package reactivemongo.bson
 
+import scala.language.implicitConversions
+
 object `package` extends DefaultBSONHandlers {
   type BSONElement = (String, BSONValue)
 }

--- a/bson/src/main/scala/handlers.scala
+++ b/bson/src/main/scala/handlers.scala
@@ -15,6 +15,7 @@
  */
 package reactivemongo.bson
 
+import scala.language.higherKinds
 import scala.collection.generic.CanBuildFrom
 import scala.util.{ Failure, Success, Try }
 

--- a/driver/src/main/scala/api/commands/aggregation.scala
+++ b/driver/src/main/scala/api/commands/aggregation.scala
@@ -1,7 +1,7 @@
 package reactivemongo.api.commands
 
-import concurrent.Future
-import reactivemongo.api.{ BSONSerializationPack, Cursor, SerializationPack }
+import scala.language.implicitConversions
+import reactivemongo.api.{ BSONSerializationPack, SerializationPack }
 
 trait AggregationFramework[P <: SerializationPack] {
   case class AggregateCursorOptions(batchSize: Int = 0)

--- a/driver/src/main/scala/api/commands/commands.scala
+++ b/driver/src/main/scala/api/commands/commands.scala
@@ -1,5 +1,8 @@
 package reactivemongo.api.commands
 
+import scala.language.higherKinds
+import scala.language.implicitConversions
+
 import concurrent.{ ExecutionContext, Future }
 import util.control.NoStackTrace
 import reactivemongo.api.{ BSONSerializationPack, Cursor, SerializationPack, SerializationPackObject, DB, Collection }

--- a/driver/src/main/scala/api/commands/count.scala
+++ b/driver/src/main/scala/api/commands/count.scala
@@ -1,7 +1,8 @@
 package reactivemongo.api.commands
 
-import concurrent.Future
-import reactivemongo.api.{ BSONSerializationPack, Cursor, SerializationPack }
+import scala.language.implicitConversions
+
+import reactivemongo.api.{ SerializationPack }
 
 
 trait CountCommand[P <: SerializationPack] extends ImplicitCommandHelpers[P] {

--- a/driver/src/main/scala/api/commands/rwcommands.scala
+++ b/driver/src/main/scala/api/commands/rwcommands.scala
@@ -1,5 +1,6 @@
 package reactivemongo.api.commands
 
+import scala.language.implicitConversions
 import scala.util.control.NoStackTrace
 import reactivemongo.api.{ BSONSerializationPack, Cursor, SerializationPack }
 import reactivemongo.bson.BSONObjectID

--- a/driver/src/main/scala/api/cursor.scala
+++ b/driver/src/main/scala/api/cursor.scala
@@ -21,6 +21,7 @@ import reactivemongo.core.netty.BufferSequence
 import reactivemongo.core.protocol._
 import reactivemongo.utils.ExtendedFutures.DelayedFuture
 import reactivemongo.utils.LazyLogger
+import scala.language.higherKinds
 import scala.annotation.tailrec
 import scala.collection.generic.CanBuildFrom
 import scala.concurrent.{ ExecutionContext, Future }

--- a/driver/src/main/scala/api/serializationpack/serializationpack.scala
+++ b/driver/src/main/scala/api/serializationpack/serializationpack.scala
@@ -1,6 +1,7 @@
 package reactivemongo.api
 
 import reactivemongo.bson.buffer.{ ReadableBuffer, WritableBuffer }
+import scala.language.higherKinds
 
 trait SerializationPack { self: Singleton =>
   type Document

--- a/driver/src/main/scala/core/actors.scala
+++ b/driver/src/main/scala/core/actors.scala
@@ -15,18 +15,21 @@
  */
 package reactivemongo.core.actors
 
+import java.net.InetSocketAddress
+
+import scala.language.postfixOps
+import scala.annotation.tailrec
+import scala.concurrent.{ Future, Promise }
+import scala.util.{ Failure, Success, Try }
+
 import akka.actor._
 import org.jboss.netty.channel.group._
+import reactivemongo.api.{ MongoConnectionOptions, ReadPreference }
 import reactivemongo.core.errors._
 import reactivemongo.core.protocol._
 import reactivemongo.utils.LazyLogger
 import reactivemongo.core.commands.{ Authenticate => AuthenticateCommand, _ }
-import scala.annotation.tailrec
-import scala.concurrent.{ Future, Promise }
-import scala.util.{ Failure, Success, Try }
 import reactivemongo.core.nodeset._
-import java.net.InetSocketAddress
-import reactivemongo.api.{ MongoConnectionOptions, ReadPreference }
 
 // messages
 
@@ -594,7 +597,11 @@ class MongoDBSystem(
     allChannelGroup(nodeSet).close.addListener(listener)
 
     // fail all requests waiting for a response
-    awaitingResponses.foreach( _._2.promise.failure(Exceptions.ClosedException) )
+    awaitingResponses.foreach { pair =>
+      val promise = pair._2.promise
+      if (!promise.isCompleted)
+        promise.failure(Exceptions.ClosedException)
+    }
     awaitingResponses.empty
 
     logger.warn(s"MongoDBSystem $self stopped.")

--- a/driver/src/main/scala/core/nodeset.scala
+++ b/driver/src/main/scala/core/nodeset.scala
@@ -2,6 +2,7 @@ package reactivemongo.core.nodeset
 
 import reactivemongo.core.protocol.Request
 import akka.actor.ActorRef
+import scala.language.higherKinds
 import scala.annotation.tailrec
 import scala.collection.generic.CanBuildFrom
 import java.util.concurrent.{ Executor, Executors }

--- a/driver/src/main/scala/utils.scala
+++ b/driver/src/main/scala/utils.scala
@@ -17,6 +17,7 @@ package reactivemongo.utils
 
 import scala.concurrent._
 import scala.concurrent.duration._
+import scala.language.implicitConversions
 
 object `package` {
   /** Concats two array - fast way */

--- a/driver/src/test/scala/CursorSpec.scala
+++ b/driver/src/test/scala/CursorSpec.scala
@@ -42,7 +42,7 @@ class CursorSpec  extends Specification {
     "get 10 first docs" in {
       println("\n\n\n\n\tGET FIRST 10 docs\n")
       //Await.result(coll.find(BSONDocument()).cursor.toListByStream(10), timeout).size mustEqual 10
-      Await.result(coll.find(BSONDocument()).cursor.toList(10), timeout).size mustEqual 10
+      Await.result(coll.find(BSONDocument()).cursor.collect[List](10), timeout).size mustEqual 10
     }
   }
 }

--- a/macros/src/main/scala/macros.scala
+++ b/macros/src/main/scala/macros.scala
@@ -1,8 +1,7 @@
 package reactivemongo.bson
 
-import collection.mutable.ListBuffer
 import reactivemongo.bson.Macros.Annotations.{Key, Ignore}
-import scala.reflect.macros.Context
+import scala.reflect.macros._
 
 /**
  * User: andraz
@@ -10,7 +9,7 @@ import scala.reflect.macros.Context
  * Time: 6:51 PM
  */
 private object MacroImpl {
-  def reader[A: c.WeakTypeTag, Opts: c.WeakTypeTag](c: Context): c.Expr[BSONDocumentReader[A]] = {
+  def reader[A: c.WeakTypeTag, Opts: c.WeakTypeTag](c: blackbox.Context): c.Expr[BSONDocumentReader[A]] = {
     val h = Helper[A,Opts](c)
     val body = h.readBody
     c.universe.reify {
@@ -20,7 +19,7 @@ private object MacroImpl {
     }
   }
 
-  def writer[A: c.WeakTypeTag, Opts: c.WeakTypeTag](c: Context): c.Expr[BSONDocumentWriter[A]] = {
+  def writer[A: c.WeakTypeTag, Opts: c.WeakTypeTag](c: blackbox.Context): c.Expr[BSONDocumentWriter[A]] = {
     val h = Helper[A,Opts](c)
     val body = h.writeBody
     c.universe.reify (
@@ -30,7 +29,7 @@ private object MacroImpl {
     )
   }
 
-  def handler[A: c.WeakTypeTag, Opts: c.WeakTypeTag](c: Context): c.Expr[BSONDocumentReader[A] with BSONDocumentWriter[A] with BSONHandler[BSONDocument, A]] = {
+  def handler[A: c.WeakTypeTag, Opts: c.WeakTypeTag](c: blackbox.Context): c.Expr[BSONDocumentReader[A] with BSONDocumentWriter[A] with BSONHandler[BSONDocument, A]] = {
     val h = Helper[A,Opts](c)
     val r = h.readBody
     val w = h.writeBody
@@ -43,12 +42,12 @@ private object MacroImpl {
     )
   }
 
-  private def Helper[A: c.WeakTypeTag, Opts: c.WeakTypeTag](c: Context) = new Helper[c.type, A](c) {
+  private def Helper[A: c.WeakTypeTag, Opts: c.WeakTypeTag](c: blackbox.Context) = new Helper[c.type, A](c) {
     val A = c.weakTypeOf[A]
     val Opts = c.weakTypeOf[Opts]
   }
 
-  private abstract class Helper[C <: Context, A](val c: C) {
+  private abstract class Helper[C <: blackbox.Context, A](val c: C) {
     protected def A: c.Type
     protected def Opts: c.Type
     import c.universe._
@@ -58,7 +57,7 @@ private object MacroImpl {
         val cases = types map { typ =>
           val pattern = Literal(Constant(typ.typeSymbol.fullName)) //todo
         val body = readBodyFromImplicit(typ)
-          CaseDef(pattern, body)
+          cq"$pattern => $body"
         }
         val className = c.parse("""document.getAs[String]("className").get""")
         Match(className, cases)
@@ -75,11 +74,11 @@ private object MacroImpl {
     lazy val writeBody: c.Expr[BSONDocument] = {
       val writer = unionTypes map { types =>
         val cases = types map { typ =>
-          val pattern = Bind(newTermName("document"), Typed(Ident(nme.WILDCARD), TypeTree(typ)))
+          val pattern = Bind(TermName("document"), Typed(Ident(termNames.WILDCARD), TypeTree(typ)))
           val body = writeBodyFromImplicit(typ)
-          CaseDef(pattern, body)
+          cq"$pattern => $body"
         }
-        Match(Ident("document"), cases)
+        Match(Ident(TermName("document")), cases)
       } getOrElse writeBodyConstruct(A)
 
       val result = c.Expr[BSONDocument](writer)
@@ -93,7 +92,7 @@ private object MacroImpl {
     private def readBodyFromImplicit(A: c.Type) = {
       val reader = c.inferImplicitValue(appliedType(readerType, List(A)))
       if(! reader.isEmpty)
-        Apply(Select(reader, "read"), List(Ident("document")))
+        Apply(Select(reader, TermName("read")), List(Ident(TermName("document"))))
       else
         readBodyConstruct(A)
     }
@@ -107,18 +106,18 @@ private object MacroImpl {
 
     private def readBodyConstructSingleton(implicit A: c.Type) = {
       val sym = A match {
-        case SingleType(_, sym) => sym
-        case TypeRef(_, sym, _) => sym
+        case SingleType(_, s) => s
+        case TypeRef(_, s, _) => s
         case _ => c.abort(c.enclosingPosition, s"Something weird is going on with '$A'. Should be a singleton but can't parse it")
       }
-      val name = stringToTermName(sym.name.toString) //this is ugly but quite stable compared to other attempts
+      val name = TermName(sym.name.toString) //this is ugly but quite stable compared to other attempts
       Ident(name)
     }
 
     private def readBodyConstructClass(implicit A: c.Type) = {
       val (constructor, _) = matchingApplyUnapply
 
-      val values = constructor.paramss.head map {
+      val values = constructor.paramLists.head map {
         param =>
           val sig = param.typeSignature
           val optTyp = optionTypeParameter(sig)
@@ -127,7 +126,7 @@ private object MacroImpl {
           if (optTyp.isDefined) {
             Apply(
               TypeApply(
-                Select(Ident("document"), "getAs"),
+                Select(Ident(TermName("document")), TermName("getAs")),
                 List(TypeTree(typ))
               ),
               List(Literal(Constant(paramName(param))))
@@ -136,30 +135,30 @@ private object MacroImpl {
           else {
             val getter = Apply(
               TypeApply(
-                Select(Ident("document"), "getAsTry"),
+                Select(Ident(TermName("document")), TermName("getAsTry")),
                 List(TypeTree(typ))
 
               ),
               List(Literal(Constant(paramName(param))))
             )
-            Select(getter, "get")
+            Select(getter, TermName("get"))
           }
 
       }
 
-      val constructorTree = Select(Ident(companion.name.toString), "apply")
+      val constructorTree = Select(Ident(TermName(companion.name.toString)), TermName("apply"))
       Apply(constructorTree, values)
     }
 
     private def writeBodyFromImplicit(A: c.Type) = {
       val writer = c.inferImplicitValue(appliedType(writerType, List(A)))
       if(! writer.isEmpty) {
-        val doc = Apply(Select(writer, "write"), List(Ident("document")))
+        val doc = Apply(Select(writer, TermName("write")), List(Ident(TermName("document"))))
         classNameTree(A) map { className =>
           val nameE = c.Expr[(String, BSONString)](className)
           val docE = c.Expr[BSONDocument](doc)
           reify{
-            docE.splice ++ BSONDocument(Seq((nameE.splice)))
+            docE.splice ++ BSONDocument(Seq(nameE.splice))
           }.tree
         } getOrElse doc
       } else
@@ -176,7 +175,7 @@ private object MacroImpl {
     private def writeBodyConstructSingleton(A: c.Type): c.Tree = {
       val expr =classNameTree(A) map { className =>
         val nameE = c.Expr[(String, BSONString)](className)
-        reify{ BSONDocument(Seq((nameE.splice))) }
+        reify{ BSONDocument(Seq(nameE.splice)) }
       } getOrElse reify{ BSONDocument.empty }
       expr.tree
     }
@@ -184,17 +183,17 @@ private object MacroImpl {
     private def writeBodyConstructClass(A: c.Type): c.Tree = {
       val (constructor, deconstructor) = matchingApplyUnapply(A)
       val types = unapplyReturnTypes(deconstructor)
-      val constructorParams = constructor.paramss.head
+      val constructorParams = constructor.paramLists.head
 
-      val tuple = Ident(newTermName("tuple"))
+      val tuple = Ident(TermName("tuple"))
       val (optional, required) = constructorParams.filterNot(ignoreField).zipWithIndex zip types partition (t => isOptionalType(t._2))
       val values = required map {
         case ((param, i), typ) => {
           val neededType = appliedType(writerType, List(typ))
           val writer = c.inferImplicitValue(neededType)
           if (writer.isEmpty) c.abort(c.enclosingPosition, s"Implicit $typ for '$param' not found")
-          val tuple_i = if (types.length == 1) tuple else Select(tuple, "_" + (i + 1))
-          val bs_value = c.Expr[BSONValue](Apply(Select(writer, "write"), List(tuple_i)))
+          val tuple_i = if (types.length == 1) tuple else Select(tuple, TermName("_" + (i + 1)))
+          val bs_value = c.Expr[BSONValue](Apply(Select(writer, TermName("write")), List(tuple_i)))
           val name = c.literal(paramName(param))
           reify(
             (name.splice, bs_value.splice): (String, BSONValue)
@@ -208,13 +207,13 @@ private object MacroImpl {
           val neededType = appliedType(writerType, List(typ))
           val writer = c.inferImplicitValue(neededType)
           if (writer.isEmpty) c.abort(c.enclosingPosition, s"Implicit $typ for '$param' not found")
-          val tuple_i= if (types.length == 1) tuple else Select(tuple, "_" + (i + 1))
-          val buf = Ident("buf")
-          val bs_value = c.Expr[BSONValue](Apply(Select(writer, "write"), List(Select(tuple_i, "get"))))
+          val tuple_i= if (types.length == 1) tuple else Select(tuple, TermName("_" + (i + 1)))
+          //val buf = Ident(TermName("buf"))
+          val bs_value = c.Expr[BSONValue](Apply(Select(writer, TermName("write")), List(Select(tuple_i, TermName("get")))))
           val name = c.literal(paramName(param))
           If(
-            Select(tuple_i, "isDefined"),
-            Apply(Select(Ident("buf"), "$plus$colon$eq"), List(reify((name.splice,bs_value.splice)).tree)),
+            Select(tuple_i, TermName("isDefined")),
+            Apply(Select(Ident(TermName("buf")), TermName("$plus$colon$eq")), List(reify((name.splice,bs_value.splice)).tree)),
             EmptyTree
           )
         }
@@ -223,16 +222,16 @@ private object MacroImpl {
       val mkBSONdoc = Apply(bsonDocPath, values ++ classNameTree(A))
 
       val withAppends = List(
-        ValDef(Modifiers(), newTermName("bson"), TypeTree(), mkBSONdoc),
+        ValDef(Modifiers(), TermName("bson"), TypeTree(), mkBSONdoc),
         c.parse("var buf = scala.collection.immutable.Stream[(String,reactivemongo.bson.BSONValue)]()")
       ) ++ appends :+ c.parse("bson.add(reactivemongo.bson.BSONDocument(buf))")
 
       val writer = if(optional.length == 0) List(mkBSONdoc) else withAppends
 
-      val unapplyTree = Select(Ident(companion(A).name.toString), "unapply")
-      val document = Ident(newTermName("document"))
-      val invokeUnapply = Select(Apply(unapplyTree, List(document)), "get")
-      val tupleDef = ValDef(Modifiers(), newTermName("tuple"), TypeTree(), invokeUnapply)
+      val unapplyTree = Select(Ident(TermName(companion(A).name.toString)), TermName("unapply"))
+      val document = Ident(TermName("document"))
+      val invokeUnapply = Select(Apply(unapplyTree, List(document)), TermName("get"))
+      val tupleDef = ValDef(Modifiers(), TermName("tuple"), TypeTree(), invokeUnapply)
 
       if(values.length + appends.length > 0){
         Block( (tupleDef :: writer): _*)
@@ -295,9 +294,9 @@ private object MacroImpl {
         case TypeRef(_, _, args) =>
           args.head match {
             case t@TypeRef(_, _, Nil) => Some(List(t))
-            case typ@TypeRef(_, t, args) =>
+            case typ@TypeRef(_, t, a) =>
               Some(
-                if (t.name.toString.matches("Tuple\\d\\d?")) args else List(typ)
+                if (t.name.toString.matches("Tuple\\d\\d?")) a else List(typ)
               )
             case _ => None
           }
@@ -321,22 +320,22 @@ private object MacroImpl {
     }
 
     private def bsonDocPath: c.universe.Select = {
-      Select(Select(Ident(newTermName("reactivemongo")), "bson"), "BSONDocument")
+      Select(Select(Ident(TermName("reactivemongo")), TermName("bson")), TermName("BSONDocument"))
     }
 
     private def paramName(param: c.Symbol): String = {
       param.annotations.collect{
-        case ann if ann.tpe =:= typeOf[Key] =>
-          ann.scalaArgs.collect{
+        case ann if ann.tree.tpe =:= typeOf[Key] =>
+          ann.tree.children.tail.collect{
             case l: Literal => l.value.value
           }.collect{
             case value: String => value
           }
       }.flatten.headOption getOrElse param.name.toString
     }
-    
+
     private def ignoreField(param: c.Symbol): Boolean = {
-      param.annotations.exists(ann => ann.tpe =:= typeOf[Ignore] || ann.tpe =:= typeOf[transient])
+      param.annotations.exists(ann => ann.tree.tpe =:= typeOf[Ignore] || ann.tree.tpe =:= typeOf[transient])
     }
 
     private def allSubclasses(A: Symbol): Set[Symbol] = {
@@ -347,18 +346,18 @@ private object MacroImpl {
 
     private def allImplementations(A: Type) = {
       val classes = allSubclasses(A.typeSymbol) map (_.asClass)
-      classes filterNot (_.isAbstractClass) map (_.toType)
+      classes filterNot (_.isAbstract) map (_.toType)
     }
 
     private def applyMethod(implicit A: c.Type): c.universe.Symbol = {
-      companion(A).typeSignature.declaration(stringToTermName("apply")) match {
+      companion(A).typeSignature.decl(TermName("apply")) match {
         case NoSymbol => c.abort(c.enclosingPosition, s"No apply function found for $A")
         case s => s
       }
     }
 
     private def unapplyMethod(implicit A: c.Type): c.universe.MethodSymbol= {
-      companion(A).typeSignature.declaration(stringToTermName("unapply")) match {
+      companion(A).typeSignature.decl(TermName("unapply")) match {
         case NoSymbol => c.abort(c.enclosingPosition, s"No unapply function found for $A")
         case s => s.asMethod
       }
@@ -371,7 +370,7 @@ private object MacroImpl {
       val alternatives = applySymbol.asTerm.alternatives map (_.asMethod)
       val u = unapplyReturnTypes(unapply)
       val applys = alternatives filter { alt =>
-        val sig = alt.paramss.head.map(_.typeSignature)
+        val sig = alt.paramLists.head.map(_.typeSignature)
         sig.size == u.size && sig.zip(u).forall {
           case (left, right) => left =:= right
         }
@@ -381,13 +380,13 @@ private object MacroImpl {
       (apply,unapply)
     }
 
-    type Reader[A] = BSONReader[_ <: BSONValue, A]
-    type Writer[A] = BSONWriter[A, _ <: BSONValue]
+    type Reader[T] = BSONReader[_ <: BSONValue, T]
+    type Writer[T] = BSONWriter[T, _ <: BSONValue]
 
     private def isSingleton(t: Type): Boolean = t <:< typeOf[Singleton]
     private def writerType: c.Type = typeOf[Writer[_]].typeConstructor
     private def readerType: c.Type = typeOf[Reader[_]].typeConstructor
 
-    private def companion(implicit A: c.Type): c.Symbol = A.typeSymbol.companionSymbol
+    private def companion(implicit A: c.Type): c.Symbol = A.typeSymbol.companion
   }
 }

--- a/project/ReactiveMongo.scala
+++ b/project/ReactiveMongo.scala
@@ -1,5 +1,6 @@
 import sbt._
 import sbt.Keys._
+import scala.language.postfixOps
 
 object BuildSettings {
   val buildVersion = "0.11.0-SNAPSHOT"
@@ -11,7 +12,7 @@ object BuildSettings {
     }
   }
 
-  val buildSettings = Defaults.defaultSettings ++ Seq(
+  val buildSettings = Defaults.coreDefaultSettings ++ Seq(
     organization := "org.reactivemongo",
     version := buildVersion,
     scalaVersion := "2.11.2",

--- a/project/ReactiveMongo.scala
+++ b/project/ReactiveMongo.scala
@@ -15,9 +15,7 @@ object BuildSettings {
   val buildSettings = Defaults.coreDefaultSettings ++ Seq(
     organization := "org.reactivemongo",
     version := buildVersion,
-    scalaVersion := "2.11.2",
-    crossScalaVersions  := Seq("2.11.2", "2.10.4"),
-    crossVersion := CrossVersion.binary,
+    scalaVersion := "2.11.4",
     javaOptions in test ++= Seq("-Xmx512m", "-XX:MaxPermSize=512m"),
     scalacOptions ++= Seq("-unchecked", "-deprecation", "-target:jvm-1.6"),
     scalacOptions in (Compile, doc) ++= Seq("-unchecked", "-deprecation", "-diagrams", "-implicits", "-skip-packages", "samples"),
@@ -45,7 +43,7 @@ object Publish {
     pomIncludeRepository := { _ => false },
     licenses := Seq("Apache 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
     homepage := Some(url("http://reactivemongo.org")),
-    pomExtra := (
+    pomExtra :=
       <scm>
         <url>git://github.com/ReactiveMongo/ReactiveMongo.git</url>
         <connection>scm:git://github.com/ReactiveMongo/ReactiveMongo.git</connection>
@@ -56,7 +54,7 @@ object Publish {
           <name>Stephane Godbillon</name>
           <url>http://stephane.godbillon.com</url>
         </developer>
-      </developers>))
+      </developers>)
 }
 
 object Format {
@@ -120,11 +118,11 @@ object Resolvers {
 }
 
 object Dependencies {
-  val netty = "io.netty" % "netty" % "3.6.5.Final" cross CrossVersion.Disabled
+  val netty = "io.netty" % "netty" % "3.6.5.Final"
 
-  val akkaActor = "com.typesafe.akka" %% "akka-actor" % "2.3.6"
+  val akkaActor = "com.typesafe.akka" %% "akka-actor" % "2.3.8"
 
-  val iteratees = "com.typesafe.play" %% "play-iteratees" % "2.3.5"
+  val iteratees = "com.typesafe.play" %% "play-iteratees" % "2.3.7"
 
   val specs = "org.specs2" %% "specs2-core" % "2.3.11" % "test"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,9 @@
-scalacOptions ++= Seq("-deprecation", "-unchecked")
+scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.2.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
 
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.4")
 
-addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.0")
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.1")


### PR DESCRIPTION
Reduce Compiler Warnings & Fix A Bug 
* Include the SBT modernization patch
* Don't cross compile, just use Scala 2.11.4
* akka-actor: 2.3.6 => 2.3.8
* play-iteratees: 2.3.5 => 2.3.7
* Fix the deprecation of Default.defaultSettings in build
* Introduce scala language options as needed to reduce warnings 
* Fix many deprecated Scala macro uses 
* Fix a bug in MongoDBSystem.postStop to avoid calling failure on an already completed 
  promise which previously threw IllegalStateException("Promise already completed")