### PR TITLE
Add `bsonCodecSeq`.

### DIFF
--- a/bson/src/main/scala/handlers.scala
+++ b/bson/src/main/scala/handlers.scala
@@ -196,6 +196,15 @@ trait DefaultBSONHandlers {
     new BSONArrayCollectionReader
   }
 
+  implicit def bsonCodecSeq[A, B <: BSONValue](implicit handler: BSONHandler[B, A], tt: ClassTag[B]): BSONHandler[BSONArray, Seq[A]] =
+    BSONHandler(
+      arr => arr.values.toSeq.map {
+        case x: B => handler.read(x)
+        case x => sys.error(s"Was expecting value of type ${tt.runtimeClass.getSimpleName} but got '$x'")
+      },
+      xs => BSONArray(xs.map(x => handler.write(x)))
+    )
+
   abstract class IdentityBSONConverter[T <: BSONValue](implicit m: Manifest[T]) extends BSONReader[T, T] with BSONWriter[T, T] {
     override def write(t: T): T = m.runtimeClass.cast(t).asInstanceOf[T]
     override def writeOpt(t: T): Option[T] = if (m.runtimeClass.isInstance(t)) Some(t.asInstanceOf[T]) else None


### PR DESCRIPTION
@sgodbillon I'm curious why there is no meta-codec defined that way?

Without it, I don't get codec for a `Seq[A]` if I have one for `A`.

I have the feeling that ` implicit def collectionToBSONArrayCollectionWriter` and `implicit def bsonArrayToCollectionReader` don't work in my case, due to the inheritance hierarchy (I have in fact defined a Handler, and those implicits don't work well with sub-typing.

I understand that you might refuse that PR in case it create ambiguity, but I wanted to show you the problem as that might affect a future redesign.