### PR TITLE
Avoid None.get when deleting an index.

### DIFF
--- a/driver/src/main/scala/core/commands/commands.scala
+++ b/driver/src/main/scala/core/commands/commands.scala
@@ -592,7 +592,7 @@ case class DeleteIndex(
 
   object ResultMaker extends BSONCommandResultMaker[Int] {
     def apply(document: BSONDocument) =
-      CommandError.checkOk(document, Some("deleteIndexes")).toLeft(document.getAs[BSONInteger]("nIndexesWas").map(_.value.toInt).get) }
+      CommandError.checkOk(document, Some("deleteIndexes")).toLeft(document.getAs[BSONNumberLike]("nIndexesWas").map(_.toInt).get) }
 }
 
 /** eval command */

--- a/driver/src/main/scala/core/commands/commands.scala
+++ b/driver/src/main/scala/core/commands/commands.scala
@@ -592,7 +592,7 @@ case class DeleteIndex(
 
   object ResultMaker extends BSONCommandResultMaker[Int] {
     def apply(document: BSONDocument) =
-      CommandError.checkOk(document, Some("deleteIndexes")).toLeft(document.getAs[BSONDouble]("nIndexesWas").map(_.value.toInt).get) }
+      CommandError.checkOk(document, Some("deleteIndexes")).toLeft(document.getAs[BSONInteger]("nIndexesWas").map(_.value.toInt).get) }
 }
 
 /** eval command */


### PR DESCRIPTION
Even if #130 adjusted the property name, I was still getting errors with mongo 2.6. 
Here is a patch against 0.10.5 that corrects the expected type of the nIndexesWas field.
