### PR TITLE
Retry the cases of Unauthorized errors.

### DIFF
--- a/driver/src/main/scala/core/actors.scala
+++ b/driver/src/main/scala/core/actors.scala
@@ -458,9 +458,10 @@ class MongoDBSystem(
               None
           }
           val ns = nodeSet.updateByChannelId(response.info.channelId) { connection =>
+            val auths = nodeSet.authenticates + originalAuthenticate
             authenticateConnection(connection.copy(
               authenticated = authenticated.map(connection.authenticated + _).getOrElse(connection.authenticated),
-              authenticating = None), nodeSet.authenticates.toSeq)
+              authenticating = None), auths.toSeq)
           } { node =>
             node.copy(authenticated = authenticated.map(node.authenticated + _).getOrElse(node.authenticated))
           }


### PR DESCRIPTION
Use the failed authentication for retry too.

The case can be reproduced by:

1. Change the user's password.
2. Try to connect (or reconnect).
3. Change the user's password back.