### PR TITLE
  Avoid None.get when deleting an index.

### DIFF
--- a/driver/src/main/scala/core/commands/commands.scala
+++ b/driver/src/main/scala/core/commands/commands.scala
@@ -608,5 +608,5 @@ case class DeleteIndex(
 
   object ResultMaker extends BSONCommandResultMaker[Int] {
     def apply(document: BSONDocument) =
-      CommandError.checkOk(document, Some("deleteIndexes")).toLeft(document.getAs[BSONDouble]("nIndexesWas").map(_.value.toInt).get) }
+      CommandError.checkOk(document, Some("deleteIndexes")).toLeft(document.getAs[BSONInteger]("nIndexesWas").map(_.value.toInt).get) }
 }

--- a/driver/src/main/scala/core/commands/commands.scala
+++ b/driver/src/main/scala/core/commands/commands.scala
@@ -608,5 +608,5 @@ case class DeleteIndex(
 
   object ResultMaker extends BSONCommandResultMaker[Int] {
     def apply(document: BSONDocument) =
-      CommandError.checkOk(document, Some("deleteIndexes")).toLeft(document.getAs[BSONInteger]("nIndexesWas").map(_.value.toInt).get) }
+      CommandError.checkOk(document, Some("deleteIndexes")).toLeft(document.getAs[BSONNumberLike]("nIndexesWas").map(_.toInt).get) }
 }


### PR DESCRIPTION
Same patch as PR #271 but applied to master instead of the 0.10.5.xxx branch.