### PR TITLE
Convenient BSON factory functions (micro-DSL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 def listDocs() = {
   // Select only the documents which field 'firstName' equals 'Jack'
-  val query = BSONDocument("firstName" -> "Jack")
+  val query = document("firstName" -> "Jack")
   // select only the fields 'lastName' and '_id'
-  val fields = BSONDocument(
+  val fields = document(
     "lastName" -> 1,
     "_id" -> 1)
 

--- a/bson/src/main/scala/bson.scala
+++ b/bson/src/main/scala/bson.scala
@@ -15,8 +15,40 @@
  */
 package reactivemongo.bson
 
+/**
+ * {{{
+ * // { "name": "Johny", "surname": "Doe", "age": 28, "months": [1, 2, 3] }
+ * document ++ ("name" -> "Johny") ++ ("surname" -> "Doe") ++
+ * ("age" -> 28) ++ ("months" -> array(1, 2, 3))
+ * 
+ * // { "_id": generatedId, "name": "Jane", "surname": "Doe", "age": 28,
+ * //   "months": [1, 2, 3], "details": { "salary": 12345,
+ * //   "inventory": ["foo", 7.8, 0, false] } }
+ * document ++ ("_id" -> generateId, "name" -> "Jane", "surname" -> "Doe",
+ *   "age" -> 28, "months" -> (array ++ (1, 2) ++ 3),
+ *   "details" -> document(
+ *     "salary" -> 12345L, "inventory" -> array("foo", 7.8, 0L, false)))
+ * }}}
+ */
 object `package` extends DefaultBSONHandlers {
   type BSONElement = (String, BSONValue)
+
+  // DSL helpers:
+
+  /** Returns an empty document. */
+  def document = BSONDocument.empty
+
+  /** Returns a document with given elements. */
+  def document(elements: Producer[BSONElement]*) = BSONDocument(elements: _*)
+
+  /** Returns an empty array. */
+  def array = BSONArray.empty
+
+  /** Returns an array with given values. */
+  def array(values: Producer[BSONValue]*) = BSONArray(values: _*)
+
+  /** Returns a newly generated object ID. */
+  def generateId = BSONObjectID.generate
 }
 
 sealed trait Producer[T] {

--- a/bson/src/test/scala/Types.scala
+++ b/bson/src/test/scala/Types.scala
@@ -33,4 +33,33 @@ class Types extends Specification {
       BSONObjectID.generate must beAnInstanceOf[BSONObjectID]
     }
   }
+
+  "BSON document" should {
+    "be empty" in {
+      BSONDocument().elements must beEmpty and (
+        BSONDocument.empty.elements must beEmpty) and (
+        document.elements must beEmpty) and (
+        document().elements must beEmpty)
+    }
+
+    "be created with a new element " in {
+      val doc = BSONDocument.empty ++ ("foo" -> 1)
+      doc must_== BSONDocument("foo" -> 1)
+    }
+  }
+
+  "BSON array" should {
+    "be empty" in {
+      BSONArray().values must beEmpty and (
+        BSONArray.empty.values must beEmpty) and (
+        array.values must beEmpty) and (
+        array().values must beEmpty)
+
+    }
+
+    "be created with a new element " in {
+      val arr = BSONArray.empty ++ ("foo", "bar")
+      arr must_== BSONArray("foo", "bar")
+    }
+  }
 }


### PR DESCRIPTION
To create following BSON doc:

```json
{ "name": "Johny", "surname": "Doe", "age": 28, "months": [1, 2, 3] }
```

```scala
import reactivemongo.bson._
document ++ ("name" -> "Johny") ++ ("surname" -> "Doe") ++
  ("age" -> 28) ++ ("months" -> array(1, 2, 3))

// Instead of :
BSONDocument() ++ ("name" -> "Johny") ++ ("surname" -> "Doe") ++
  ("age" -> 28) ++ ("months" -> array(1, 2, 3))
```

> Just a minor syntax sugar about `BSONDocument()` with `document`.

To create a more complex doc:

```json
{
  "_id": generatedId, 
  "name": "Jane", 
  "surname": "Doe", 
  "age": 28,
  "months": [1, 2, 3], 
  "details": {
    "salary": 12345,
    "inventory": ["foo", 7.8, 0, false]
  }
}
```

```scala
document(
  "_id" -> generateId,
  "name" -> "Jane",
  "surname" -> "Doe",
  "age" -> 28, "months" -> (array ++ (1, 2) ++ 3),
  "details" -> document ++ (
    "salary" -> 12345L, 
    "inventory" -> array("foo", 7.8, 0L, false)
  )
)
```