### PR TITLE
Adds ability to save simple name io. fully qualified

### DIFF
--- a/macros/src/main/scala/interface.scala
+++ b/macros/src/main/scala/interface.scala
@@ -113,6 +113,12 @@ object Macros {
     trait SaveClassName extends Default
 
     /**
+     * Same as [[SaveClassName]] but using the class’ simple name, io.
+     * the fully-qualified name.
+     */
+    trait SaveSimpleName extends SaveClassName with Default
+
+    /**
      * Use type parameter `A` as static type but use pattern matching to handle
      * different possible subtypes. This makes it easy to persist algebraic
      * data types(pattern where you have a sealed trait and several implementing
@@ -144,6 +150,13 @@ object Macros {
     trait UnionType[Types <: \/[_, _]] extends SaveClassName with Default
 
     /**
+     * Same as [[UnionType]] but saving the class’ simple name io. the
+     * fully-qualified name.
+     * @tparam Types to use in pattern matching. Listed in a "type list" \/
+     */
+    trait SimpleUnionType[Types <: \/[_, _]] extends UnionType[Types] with SaveSimpleName with Default
+
+    /**
      * Type for making type-level lists for UnionType.
      * If second parameter is another \/ it will be flattend out into a list
      * and so on. Using infix notation makes much more sense since it then
@@ -172,6 +185,11 @@ object Macros {
      * }}}
      */
     trait AllImplementations extends SaveClassName with Default
+
+    /**
+     * Same as [[AllImplementations]] but saving the simple name io. the fully-qualified name.
+     */
+    trait SimpleAllImplementations extends AllImplementations with SaveSimpleName with Default
   }
 
   /**

--- a/macros/src/main/scala/macros.scala
+++ b/macros/src/main/scala/macros.scala
@@ -1,5 +1,7 @@
 package reactivemongo.bson
 
+import reactivemongo.bson.Macros.Options.SaveSimpleName
+
 import collection.mutable.ListBuffer
 import reactivemongo.bson.Macros.Annotations.{Key, Ignore}
 import scala.reflect.macros.Context
@@ -56,8 +58,12 @@ private object MacroImpl {
     lazy val readBody: c.Expr[A] = {
       val writer = unionTypes map { types =>
         val cases = types map { typ =>
-          val pattern = Literal(Constant(typ.typeSymbol.fullName)) //todo
-        val body = readBodyFromImplicit(typ)
+          val pattern = if (hasOption[SaveSimpleName])
+            Literal(Constant(typ.typeSymbol.name.decodedName.toString))
+          else
+            Literal(Constant(typ.typeSymbol.fullName)) //todo
+
+          val body = readBodyFromImplicit(typ)
           CaseDef(pattern, body)
         }
         val className = c.parse("""document.getAs[String]("className").get""")
@@ -243,7 +249,11 @@ private object MacroImpl {
 
     private def classNameTree(A: c.Type) = {
       val className = if (hasOption[Macros.Options.SaveClassName]) Some {
-        val name = c.literal(A.typeSymbol.fullName)
+        val name = if (hasOption[Macros.Options.SaveSimpleName])
+          c.literal(A.typeSymbol.name.decodedName.toString)
+        else
+          c.literal(A.typeSymbol.fullName)
+
         reify {
           ("className", BSONStringHandler.write(name.splice))
         }.tree


### PR DESCRIPTION
`UnionType` and `AllImplementations` (in cooperation with `SaveClassName`) use the fully-qualified class name of a class to determine the run-time type of a record. The fact that the fully-qualified name is used, makes it more difficult to refactor a project’s package structure, after its initial release to production.

In order to alleviate this problem, for projects that are in full control of the package structure of the entities they are storing and want to keep their options open, this change adds “simple” versions of `SaveClassName`, `UnionTypes`and `AllImplementations` (`SaveSimpleName`, `SimpleUnionTypes` and `SimpleAllImplementations`, respectively), that do the same except that they store and match on the classes’ simple names.