### PR TITLE
Add method for BSONBinary to return payload as Array[Byte]

### DIFF
--- a/bson/src/main/scala/types.scala
+++ b/bson/src/main/scala/types.scala
@@ -289,7 +289,13 @@ object BSONArray {
  * @param value The binary content.
  * @param subtype The type of the binary content.
  */
-case class BSONBinary(value: ReadableBuffer, subtype: Subtype) extends BSONValue { val code = 0x05.toByte } // TODO
+case class BSONBinary(value: ReadableBuffer, subtype: Subtype)
+    extends BSONValue {
+  val code = 0x05.toByte
+
+  /** Returns the whole binary content as array. */
+  def byteArray: Array[Byte] = value.readArray(value.size)
+} // TODO
 
 object BSONBinary {
   def apply(value: Array[Byte], subtype: Subtype): BSONBinary =

--- a/bson/src/test/scala/Types.scala
+++ b/bson/src/test/scala/Types.scala
@@ -62,4 +62,13 @@ class Types extends Specification {
       arr must_== BSONArray("foo", "bar")
     }
   }
+
+  "BSONBinary" should {
+    "be read as byte array" in {
+      val bytes = Array[Byte](1,2,3)
+      val bson = BSONBinary(bytes, Subtype.GenericBinarySubtype)
+
+      bson.byteArray must_== bytes
+    }
+  }
 }


### PR DESCRIPTION
In 0.8 you can return an Array[Byte] as follows:

    doc.getAs[BSONBinary]("message").get.value.array()

In 0.9 your required to do it as follows:

    doc.getAs[BSONBinary]("message").get.value.readArray(doc.getAs[BSONBinary]("message").get.value.readable()))