### PR TITLE
Maximum gridfs file size too low

### DIFF
--- a/project/ReactiveMongo.scala
+++ b/project/ReactiveMongo.scala
@@ -3,7 +3,7 @@ import sbt.Keys._
 import scala.language.postfixOps
 
 object BuildSettings {
-  val buildVersion = "0.11.0-M3"
+  val buildVersion = "0.12.0-SNAPSHOT"
 
   val filter = { (ms: Seq[(File, String)]) =>
     ms filter {
@@ -15,8 +15,8 @@ object BuildSettings {
   val buildSettings = Defaults.coreDefaultSettings ++ Seq(
     organization := "org.reactivemongo",
     version := buildVersion,
-    scalaVersion := "2.11.2",
-    crossScalaVersions  := Seq("2.11.2", "2.10.4"),
+    scalaVersion := "2.11.6",
+    crossScalaVersions  := Seq("2.11.6", "2.10.4"),
     crossVersion := CrossVersion.binary,
     javaOptions in test ++= Seq("-Xmx512m", "-XX:MaxPermSize=512m"),
     //fork in Test := true, // Don't share executioncontext between SBT CLI/tests


### PR DESCRIPTION
Currently, the type of the `length` field of the `ComputedMetadata` trait is `Int` which effectively limits the maximum file size to 2147483647 Bytes / 2GiB.

Looking at the mongofiles tool https://github.com/mongodb/mongo-tools/blob/master/mongofiles/mongofiles.go#L55 the field is declared as a 64 bit integer which suggests that the actual maximum file size is a lot larger.