### PR TITLE
BSONTimestamp improvements & tests

### DIFF
--- a/bson/src/main/scala/types.scala
+++ b/bson/src/main/scala/types.scala
@@ -544,8 +544,16 @@ case class BSONJavaScriptWS(value: String) extends BSONValue { val code = 0x0F.t
 /** BSON Integer value */
 case class BSONInteger(value: Int) extends BSONValue { val code = 0x10.toByte }
 
-/** BSON Timestamp value. TODO */
-case class BSONTimestamp(value: Long) extends BSONValue { val code = 0x11.toByte }
+/** BSON Timestamp value */
+case class BSONTimestamp(value: Long) extends BSONValue {
+  val code = 0x11.toByte
+
+  /** Seconds since the Unix epoch */
+  val time = value >>> 32
+
+  /** Ordinal (with the second) */
+  val ordinal = value.toInt
+}
 
 /** BSON Long value */
 case class BSONLong(value: Long) extends BSONValue { val code = 0x12.toByte }

--- a/bson/src/test/scala/Types.scala
+++ b/bson/src/test/scala/Types.scala
@@ -78,4 +78,14 @@ class Types extends Specification {
       bson.byteArray must_== bytes
     }
   }
+
+  "BSONTimestamp" should {
+    "extract time and ordinal values" in {
+      val ts = BSONTimestamp(6065270725701271558L)
+
+      ts.value aka "raw value" must_== 6065270725701271558L and (
+        ts.time aka "time" must_== 1412180887L) and (
+        ts.ordinal aka "ordinal" must_== 6)
+    }
+  }
 }


### PR DESCRIPTION
`.time` and `.ordinal` extracted from the raw value