### PR TITLE
Connections per node could be set only via MongoConnectionOptions argument

### DIFF
--- a/driver/src/main/scala/api/gridfs.scala
+++ b/driver/src/main/scala/api/gridfs.scala
@@ -162,7 +162,7 @@ class GridFS[P <: SerializationPack with Singleton](db: DB with DBMetaCommands, 
    *
    * @tparam S The type of the selector document. An implicit `Writer[S]` must be in the scope.
    */
-  def find[S, T <: ReadFile[P, _]](selector: S)(implicit sWriter: pack.Writer[S], readFileReader: pack.Reader[T], ctx: ExecutionContext, cp: CursorProducer[T]): cp.ProducedCursor = files.find(selector).cursor
+  def find[S, T <: ReadFile[P, _]](selector: S)(implicit sWriter: pack.Writer[S], readFileReader: pack.Reader[T], ctx: ExecutionContext, cp: CursorProducer[T]): cp.ProducedCursor = files.find(selector).cursor()
 
   /**
    * Saves the content provided by the given enumerator with the given metadata.
@@ -286,7 +286,7 @@ class GridFS[P <: SerializationPack with Singleton](db: DB with DBMetaCommands, 
             if (file.length % file.chunkSize > 0) 1 else 0))))),
       "$orderby" -> BSONDocument("n" -> BSONInteger(1)))
 
-    val cursor = chunks.as[BSONCollection]().find(selector).cursor
+    val cursor = chunks.as[BSONCollection]().find(selector).cursor()
     cursor.enumerate() &> Enumeratee.map { doc =>
       doc.get("data").flatMap {
         case BSONBinary(data, _) => {

--- a/driver/src/test/scala/CursorSpec.scala
+++ b/driver/src/test/scala/CursorSpec.scala
@@ -29,22 +29,19 @@ class CursorSpec extends Specification {
       println("inserted 16,517 records")
       success
     }
+
     "get all the 16,517 documents" in {
       var i = 0
-      val future = coll.find(BSONDocument()).cursor.enumerate() |>>> (Iteratee.foreach({ e =>
+      val future = coll.find(BSONDocument()).cursor().enumerate() |>>> (Iteratee.foreach({ e =>
         //println(s"doc $i => $e")
         i += 1
       }))
-      /*val future = coll.find(BSONDocument()).cursor.documentStream.map { doc =>
-        i += 1
-        println("fetched " + doc)
-        doc
-       }.runLast*/
+
       future.map(_ => i) must beEqualTo(16517).await(21000 /*21s*/ )
     }
 
     "get 10 first docs" in {
-      coll.find(BSONDocument()).cursor.collect[List](10).map(_.size).
+      coll.find(BSONDocument()).cursor().collect[List](10).map(_.size).
         aka("result size") must beEqualTo(10).await(timeoutMillis)
     }
 
@@ -59,7 +56,7 @@ class CursorSpec extends Specification {
           new FlattenedFooCursor(future)
       }
 
-      val cursor = coll.find(BSONDocument()).cursor
+      val cursor = coll.find(BSONDocument()).cursor()
 
       cursor.foo must_== "Bar" and (
         Cursor.flatten(Future.successful(cursor)).foo must_== "raB")
@@ -90,7 +87,7 @@ class CursorSpec extends Specification {
       @inline def cursor(n: String): Cursor[Int] = {
         implicit val reader = IdReader
         Cursor.flatten(collection(n).map(_.find(BSONDocument()).
-          sort(BSONDocument("id" -> 1)).cursor[Int]))
+          sort(BSONDocument("id" -> 1)).cursor[Int]()))
       }
 
       "successfully using cursor" in {
@@ -117,7 +114,7 @@ class CursorSpec extends Specification {
       @inline def tailable(n: String, database: DB = db) = {
         implicit val reader = IdReader
         collection(n, database).find(BSONDocument()).options(
-          QueryOpts().tailable).cursor[Int]
+          QueryOpts().tailable).cursor[Int]()
       }
 
       "successfully using tailable enumerator with maxDocs" in {


### PR DESCRIPTION
ReactiveMongo 2.10 does not use the *nbChannelsPerNode* argument value in the **connection** method. Only *options* could be used to controll the number of connections per node.

```scala
  /**
   * Creates a new MongoConnection.
   *
   * See [[http://docs.mongodb.org/manual/reference/connection-string/ the MongoDB URI documentation]] for more information.
   *
   * @param nodes A list of node names, like ''node1.foo.com:27017''. Port is optional, it is 27017 by default.
   * @param authentications A list of Authenticates.
   * @param nbChannelsPerNode Number of channels to open per node. Defaults to 10.
   * @param name The name of the newly created [[reactivemongo.core.actors.MongoDBSystem]] actor, if needed.
   * @param options Options for the new connection pool.
   */
  def connection(nodes: Seq[String], options: MongoConnectionOptions = MongoConnectionOptions(), authentications: Seq[Authenticate] = Seq.empty, nbChannelsPerNode: Int = 10, name: Option[String] = None): MongoConnection = {
    val props = Props(new MongoDBSystem(nodes, authentications, options)())
    val mongosystem = if (name.isDefined) system.actorOf(props, name = name.get) else system.actorOf(props)
    val monitor = system.actorOf(Props(new MonitorActor(mongosystem)))
    val connection = new MongoConnection(system, mongosystem, monitor, options)
    this.synchronized {
      _connections = connection :: _connections
    }
    connection
  }
```

So, all the overloads of the **connection** method with contai the *nbChannelsPerNode* argument doesn't work properly.