### PR TITLE
Add a config param to specify the default Write Concern for all operations

### DIFF
--- a/driver/src/main/scala/api/ReadPreference.scala
+++ b/driver/src/main/scala/api/ReadPreference.scala
@@ -1,6 +1,6 @@
 package reactivemongo.api
 
-import reactivemongo.bson._
+import reactivemongo.bson.{ BSONArray, BSONDocument, BSONDocumentWriter }
 
 /**
  * MongoDB Read Preferences enable to read from primary or secondaries

--- a/driver/src/main/scala/api/collections/genericquerybuilder.scala
+++ b/driver/src/main/scala/api/collections/genericquerybuilder.scala
@@ -44,8 +44,6 @@ trait GenericQueryBuilder[P <: SerializationPack] {
 
   def merge(readPreference: ReadPreference): pack.Document
 
-  //def structureReader: pack.Reader[pack.Document]
-
   def copy(
     queryOption: Option[pack.Document] = queryOption,
     sortOption: Option[pack.Document] = sortOption,

--- a/driver/src/main/scala/api/commands/rwcommands.scala
+++ b/driver/src/main/scala/api/commands/rwcommands.scala
@@ -11,7 +11,9 @@ case class GetLastError(
   w: GetLastError.W,
   j: Boolean,
   fsync: Boolean,
-  wtimeout: Option[Int] = None) extends Command with CommandWithResult[LastError]
+  wtimeout: Option[Int] = None) extends Command
+    with CommandWithResult[LastError]
+
 object GetLastError {
   sealed trait W
   case object Majority extends W
@@ -24,17 +26,20 @@ object GetLastError {
 
   val Unacknowledged: GetLastError =
     GetLastError(WaitForAknowledgments(0), false, false, None)
+
   val Acknowledged: GetLastError =
     GetLastError(WaitForAknowledgments(1), false, false, None)
+
   val Journaled: GetLastError =
     GetLastError(WaitForAknowledgments(1), true, false, None)
-  def ReplicaAcknowledged(n: Int, timeout: Int, journaled: Boolean): GetLastError =
-    GetLastError(WaitForAknowledgments(if (n < 2) 2 else n), journaled, false, (if (timeout <= 0) None else Some(timeout)))
-  def TagReplicaAcknowledged(tag: String, timeout: Int, journaled: Boolean): GetLastError =
-    GetLastError(TagSet(tag), journaled, false, (if (timeout <= 0) None else Some(timeout)))
+
+  def ReplicaAcknowledged(n: Int, timeout: Int, journaled: Boolean): GetLastError = GetLastError(WaitForAknowledgments(if (n < 2) 2 else n), journaled, false, (if (timeout <= 0) None else Some(timeout)))
+
+  def TagReplicaAcknowledged(tag: String, timeout: Int, journaled: Boolean): GetLastError = GetLastError(TagSet(tag), journaled, false, (if (timeout <= 0) None else Some(timeout)))
 
   def Default: GetLastError = Acknowledged
 }
+
 case class LastError(
     ok: Boolean,
     err: Option[String],
@@ -179,10 +184,9 @@ trait InsertCommand[P <: SerializationPack] extends ImplicitCommandHelpers[P] {
   type InsertResult = DefaultWriteResult // for simplified imports
 
   object Insert {
-    def apply(firstDoc: ImplicitlyDocumentProducer, otherDocs: ImplicitlyDocumentProducer*): Insert =
-      apply()(firstDoc, otherDocs: _*)
-    def apply(ordered: Boolean = true, writeConcern: WriteConcern = WriteConcern.Default)(firstDoc: ImplicitlyDocumentProducer, otherDocs: ImplicitlyDocumentProducer*): Insert =
-      new Insert(firstDoc.produce #:: otherDocs.toStream.map(_.produce), ordered, writeConcern)
+    def apply(firstDoc: ImplicitlyDocumentProducer, otherDocs: ImplicitlyDocumentProducer*): Insert = apply()(firstDoc, otherDocs: _*)
+
+    def apply(ordered: Boolean = true, writeConcern: WriteConcern = WriteConcern.Default)(firstDoc: ImplicitlyDocumentProducer, otherDocs: ImplicitlyDocumentProducer*): Insert = new Insert(firstDoc.produce #:: otherDocs.toStream.map(_.produce), ordered, writeConcern)
   }
 }
 

--- a/driver/src/main/scala/api/indexes.scala
+++ b/driver/src/main/scala/api/indexes.scala
@@ -18,7 +18,6 @@ package reactivemongo.api.indexes
 import reactivemongo.core.protocol.MongoWireVersion
 import reactivemongo.api._
 import reactivemongo.bson._
-import DefaultBSONHandlers._
 import reactivemongo.api.commands.{ DropIndexes, LastError, WriteResult }
 import reactivemongo.utils.option
 import reactivemongo.core.netty._
@@ -209,7 +208,7 @@ final class LegacyIndexesManager(db: DB)(
 
   val collection = db("system.indexes")
 
-  def list(): Future[List[NSIndex]] = collection.find(BSONDocument()).cursor(IndexesManager.NSIndexReader, context, CursorProducer.defaultCursorProducer).collect[List]()
+  def list(): Future[List[NSIndex]] = collection.find(BSONDocument()).cursor(db.connection.options.readPreference)(IndexesManager.NSIndexReader, context, CursorProducer.defaultCursorProducer).collect[List]()
 
   def ensure(nsIndex: NSIndex): Future[Boolean] = {
     val query = BSONDocument(

--- a/driver/src/test/scala/CommonUseCases.scala
+++ b/driver/src/test/scala/CommonUseCases.scala
@@ -41,11 +41,11 @@ class CommonUseCases extends Specification {
     }
     "find them" in {
       // batchSize (>1) allows us to test cursors ;)
-      val it = collection.find(BSONDocument()).options(QueryOpts().batchSize(2)).cursor[BSONDocument]
+      val it = collection.find(BSONDocument()).options(QueryOpts().batchSize(2)).cursor[BSONDocument]()
       Await.result(it.collect[List](), timeout).map(_.getAs[BSONInteger]("age").get.value).mkString("") mustEqual (18 to 60).mkString("")
     }
     "find by regexp" in {
-      Await.result(collection.find(BSONDocument("name" -> BSONRegex("ack2", ""))).cursor[BSONDocument].collect[List](), timeout).size mustEqual 10
+      Await.result(collection.find(BSONDocument("name" -> BSONRegex("ack2", ""))).cursor[BSONDocument]().collect[List](), timeout).size mustEqual 10
     }
     "find by regexp with flag" in {
       val q =
@@ -53,11 +53,11 @@ class CommonUseCases extends Specification {
           "$or" -> BSONArray(
             BSONDocument("name" -> BSONRegex("^jack2", "i")),
             BSONDocument("name" -> BSONRegex("^jack3", "i"))))
-      Await.result(collection.find(q).cursor[BSONDocument].collect[List](), timeout).size mustEqual 20
+      Await.result(collection.find(q).cursor[BSONDocument]().collect[List](), timeout).size mustEqual 20
     }
     "find them with a projection" in {
       val pjn = BSONDocument("name" -> BSONInteger(1), "age" -> BSONInteger(1), "something" -> BSONInteger(1))
-      val it = collection.find(BSONDocument(), pjn).options(QueryOpts().batchSize(2)).cursor[BSONDocument]
+      val it = collection.find(BSONDocument(), pjn).options(QueryOpts().batchSize(2)).cursor[BSONDocument]()
       Await.result(it.collect[List](), timeout).map(_.getAs[BSONInteger]("age").get.value).mkString("") mustEqual (18 to 60).mkString("")
     }
     "insert a document containing a merged array of objects, fetch and check it" in {

--- a/driver/src/test/scala/commands/queryandwrite.scala
+++ b/driver/src/test/scala/commands/queryandwrite.scala
@@ -32,7 +32,7 @@ object QueryAndWriteCommands extends org.specs2.mutable.Specification {
       /*val lastError2 = Await.result(Command.run(BSONSerializationPack)(collection,Insert(true)(doc)), timeout)
       println(lastError2)
       lastError2.ok mustEqual true*/
-      val found = Await.result(collection.find(doc).cursor[BSONDocument].collect[List](), timeout)
+      val found = Await.result(collection.find(doc).cursor[BSONDocument]().collect[List](), timeout)
       found.size mustEqual 1
       val count = Await.result(Command.run(BSONSerializationPack).unboxed(collection, Count(BSONDocument())), timeout)
       count mustEqual 1
@@ -49,7 +49,7 @@ object QueryAndWriteCommands extends org.specs2.mutable.Specification {
       /*val lastError2 = Await.result(Command.run(BSONSerializationPack)(collection,Insert(true)(doc)), timeout)
       println(lastError2)
       lastError2.ok mustEqual true*/
-      val found = Await.result(collection.find(doc).cursor[BSONDocument].collect[List](), timeout)
+      val found = Await.result(collection.find(doc).cursor[BSONDocument]().collect[List](), timeout)
       found.size mustEqual 1
     }
   }
@@ -65,7 +65,7 @@ object QueryAndWriteCommands extends org.specs2.mutable.Specification {
       val lastError = Await.result(coll.insert(doc), timeout)
       println(lastError)
       lastError.ok mustEqual true
-      val list = Await.result(coll.find(doc).cursor[BSONDocument].collect[List](), timeout)
+      val list = Await.result(coll.find(doc).cursor[BSONDocument]().collect[List](), timeout)
       println(list)
       list.size mustEqual 1
     }


### PR DESCRIPTION
It would be nice for devops to have a config parameter that defines default write concern for all operations.

Developpers can then override the default WR operation by operation if needed but hosting can decide for a basic level of service.

It would also be cool to have the config parameters from play config file.

Thanks