### PR TITLE
Review BSONTimestamp constructor

### DIFF
--- a/bson/src/main/scala/types.scala
+++ b/bson/src/main/scala/types.scala
@@ -556,6 +556,18 @@ case class BSONTimestamp(value: Long) extends BSONValue {
   val ordinal = value.toInt
 }
 
+/** Timestamp companion */
+object BSONTimestamp {
+  /**
+   * Returns the timestamp corresponding to the given `time` and `ordinal`.
+   *
+   * @param time the 32bits time value (seconds since the Unix epoch)
+   * @param ordinal an incrementing ordinal for operations within a same second
+   */
+  def apply(time: Long, ordinal: Int): BSONTimestamp =
+    BSONTimestamp((time << 32) ^ ordinal)
+}
+
 /** BSON Long value */
 case class BSONLong(value: Long) extends BSONValue { val code = 0x12.toByte }
 

--- a/bson/src/test/scala/Types.scala
+++ b/bson/src/test/scala/Types.scala
@@ -87,5 +87,9 @@ class Types extends Specification {
         ts.time aka "time" must_== 1412180887L) and (
           ts.ordinal aka "ordinal" must_== 6)
     }
+
+    "be created from the time and ordinal values" in {
+      BSONTimestamp(1412180887L, 6) must_== BSONTimestamp(6065270725701271558L)
+    }
   }
 }


### PR DESCRIPTION
Using time + ordinal rather (along with the constructor based on the single long value)