### PR TITLE
Fix handling of @Ignore field annotation

### DIFF
--- a/macros/src/main/scala/macros.scala
+++ b/macros/src/main/scala/macros.scala
@@ -185,7 +185,7 @@ private object MacroImpl {
       val constructorParams = constructor.paramss.head
 
       val tuple = Ident(newTermName("tuple"))
-      val (optional, required) = constructorParams.zipWithIndex.filterNot(p => ignoreField(p._1)) zip types partition (t => isOptionalType(t._2))
+      val (optional, required) = constructorParams.filterNot(ignoreField).zipWithIndex zip types partition (t => isOptionalType(t._2)) //constructorParams.zipWithIndex.filterNot(p => ignoreField(p._1)) zip types partition (t => isOptionalType(t._2))
       val values = required map {
         case ((param, i), typ) => {
           val neededType = appliedType(writerType, List(typ))

--- a/macros/src/main/scala/macros.scala
+++ b/macros/src/main/scala/macros.scala
@@ -185,7 +185,7 @@ private object MacroImpl {
       val constructorParams = constructor.paramss.head
 
       val tuple = Ident(newTermName("tuple"))
-      val (optional, required) = constructorParams.filterNot(ignoreField).zipWithIndex zip types partition (t => isOptionalType(t._2))
+      val (optional, required) = constructorParams.zipWithIndex.filterNot(p => ignoreField(p._1)) zip types partition (t => isOptionalType(t._2))
       val values = required map {
         case ((param, i), typ) => {
           val neededType = appliedType(writerType, List(typ))

--- a/macros/src/test/scala/macrospec.scala
+++ b/macros/src/test/scala/macrospec.scala
@@ -326,6 +326,7 @@ class Macros extends Specification {
     "skip ignored fields" in {
       val doc = pairHandler.write(Pair(left = "left", right = "right"))
 
+      println("pairHandler.write: " + BSONDocument.pretty(doc))
       doc.isEmpty must beFalse
       doc.aka(BSONDocument.pretty(doc)) mustEqual BSONDocument("right" -> "right")
     }

--- a/macros/src/test/scala/macrospec.scala
+++ b/macros/src/test/scala/macrospec.scala
@@ -1,7 +1,7 @@
 import reactivemongo.bson._
 import org.specs2.mutable._
 import reactivemongo.bson.exceptions.DocumentKeyNotFound
-import reactivemongo.bson.Macros.Annotations.Key
+import reactivemongo.bson.Macros.Annotations.{ Key, Ignore }
 
 class Macros extends Specification {
   type Handler[A] = BSONDocumentReader[A] with BSONDocumentWriter[A] with BSONHandler[BSONDocument, A]
@@ -104,6 +104,10 @@ class Macros extends Specification {
     sealed trait TT extends T
     case class C() extends TT
   }
+
+  case class Pair(@Ignore left: String, right: String)
+
+  val pairHandler = Macros.handler[Pair]
 
   "Formatter" should {
     "handle primitives" in {
@@ -317,6 +321,13 @@ class Macros extends Specification {
       println(BSONDocument.pretty(serialized))
       serialized mustEqual BSONDocument("_id" -> doc.myID, "value" -> doc.value)
       format.read(serialized) mustEqual doc
+    }
+
+    "skip ignored fields" in {
+      val doc = pairHandler.write(Pair(left = "left", right = "right"))
+
+      doc.isEmpty must beFalse
+      doc.aka(BSONDocument.pretty(doc)) mustEqual BSONDocument("right" -> "right")
     }
   }
 


### PR DESCRIPTION
When annotating a field with `@Ignore` that field was skipped by the
macro expansion, but the index of the field was wrong, so the wrong
value was written to the BSON document.

Fixes #325