### PR TITLE
Version 0.11.9 depends on non-existant play-iteratees_2.11:2.3.5

### DIFF
--- a/project/ReactiveMongo.scala
+++ b/project/ReactiveMongo.scala
@@ -136,9 +136,9 @@ object Dependencies {
 
   val akkaActor = "com.typesafe.akka" %% "akka-actor" % "2.3.6"
 
-  val iteratees = "com.typesafe.play" %% "play-iteratees" % "2.3.5"
+  val iteratees = "com.typesafe.play" %% "play-iteratees" % "2.3.10"
 
-  val specs = "org.specs2" %% "specs2-core" % "2.4.9" % "test"
+  val specs = "org.specs2" %% "specs2-core" % "2.4.9" % Test
 
   val log4jVersion = "2.0.2"
   val log4j = Seq("org.apache.logging.log4j" % "log4j-api" % log4jVersion, "org.apache.logging.log4j" % "log4j-core" % log4jVersion)


### PR DESCRIPTION
Looks like version 2.3.5 of play-iteratees_2.11 does not exist in the mvn repos:

http://mvnrepository.com/artifact/org.reactivemongo/reactivemongo_2.11/0.11.9