### PR TITLE
RawCommand deprecation information is invalid

### DIFF
--- a/driver/src/main/scala/core/commands/commands.scala
+++ b/driver/src/main/scala/core/commands/commands.scala
@@ -207,7 +207,7 @@ class MakableCommand(val db: String, val command: Command[_]) {
   }
 }
 
-@deprecated("consider using reactivemongo.api.commands.RawCommand instead", "0.11.0")
+@deprecated("consider using `rawCommand` on [[reactivemongo.api.collections.GenericCollection.runner]] instead", "0.11.0")
 case class RawCommand(bson: BSONDocument) extends Command[BSONDocument] {
   val makeDocuments = bson
 


### PR DESCRIPTION
reactivemongo.core.commands.RawCommand has deprecation
`@deprecated("consider using reactivemongo.api.commands.RawCommand instead", "0.11.0")`
but such type does not exist in 0.11.0 nor in 0.11.9