### PR TITLE
Doesn't fail when dropping not existing collection

### DIFF
--- a/driver/src/main/scala/api/collection.scala
+++ b/driver/src/main/scala/api/collection.scala
@@ -15,6 +15,8 @@
  */
 package reactivemongo.api
 
+import reactivemongo.core.errors.GenericDatabaseException
+
 /**
  * A MongoDB Collection. You should consider the default BSON implementation.
  *
@@ -125,7 +127,6 @@ trait CollectionMetaCommands {
   import reactivemongo.api.commands.bson._
   import CommonImplicits._
   import BSONCreateImplicits._
-  import BSONDropImplicits._
   import BSONEmptyCappedImplicits._
   import BSONCollStatsImplicits._
   import BSONRenameCollectionImplicits._
@@ -151,15 +152,41 @@ trait CollectionMetaCommands {
    * @param autoIndexId States if should automatically add an index on the _id field. By default, capped collections will NOT have an indexed _id field, in contrast to regular collections.
    */
   def createCapped(size: Long, maxDocuments: Option[Int], autoIndexId: Boolean = false)(implicit ec: ExecutionContext): Future[Unit] =
-    Command.run(BSONSerializationPack).unboxed(self, Create(Some(Capped(size, maxDocuments)), autoIndexId))
+    Command.run(BSONSerializationPack).
+      unboxed(self, Create(Some(Capped(size, maxDocuments)), autoIndexId))
 
   /**
    * Drops this collection.
    *
-   * The returned future will be completed with an error if this collection does not exist.
+   * The returned future will be completed with an error
+   * if this collection does not exist.
    */
+  @deprecated("Use [[drop(Boolean)]]", "0.12.0")
   def drop()(implicit ec: ExecutionContext): Future[Unit] =
-    Command.run(BSONSerializationPack).unboxed(self, Drop)
+    drop(true).map(_ => {})
+
+  /**
+   * Drops this collection.
+   *
+   * If the collection existed and is successfully dropped,
+   * the returned future will be completed with true.
+   *
+   * If `failIfNotFound` is false and the collection doesn't exist,
+   * the returned future will be completed with false.
+   *
+   * Otherwise in case, the future will be completed with the encountered error.
+   */
+  def drop(failIfNotFound: Boolean)(implicit ec: ExecutionContext): Future[Boolean] = {
+    import BSONDropCollectionImplicits._
+
+    Command.run(BSONSerializationPack)(self, DropCollection).flatMap {
+      case DropCollectionResult(false) if (failIfNotFound) =>
+        Future.failed[Boolean](GenericDatabaseException(
+          s"fails to drop collection: $name", Some(26)))
+
+      case _ => Future.successful(true)
+    }
+  }
 
   /**
    * If this collection is capped, removes all the documents it contains.

--- a/driver/src/main/scala/api/commands/instanceadministration.scala
+++ b/driver/src/main/scala/api/commands/instanceadministration.scala
@@ -2,14 +2,24 @@ package reactivemongo.api.commands
 
 object DropDatabase extends Command with CommandWithResult[UnitBox.type]
 
+@deprecated("Use [[DropCollection]]", "0.12.0")
 object Drop extends CollectionCommand with CommandWithResult[UnitBox.type]
+
+/**
+ * @param dropped true if the collection existed and was dropped
+ */
+case class DropCollectionResult(dropped: Boolean)
+
+object DropCollection extends CollectionCommand
+  with CommandWithResult[DropCollectionResult]
 
 object EmptyCapped extends CollectionCommand with CommandWithResult[UnitBox.type]
 
 case class RenameCollection(
   fullyQualifiedCollectionName: String,
   fullyQualifiedTargetName: String,
-  dropTarget: Boolean = false) extends Command with CommandWithResult[UnitBox.type]
+  dropTarget: Boolean = false)
+    extends Command with CommandWithResult[UnitBox.type]
 
 case class Create(
   capped: Option[Capped] = None, // if set, "capped" -> true, size -> <int>, max -> <int>


### PR DESCRIPTION
The new operation `.drop(Boolean)` on collection no longer returns a `Future[Unit]` but a `Future[Boolean]`, to handle the following cases.

- successfully dropped an existing collection: `Future.successful(true)`,
- (with `failIfNotFound = false`) successfully try to drop, but collection doesn't exist: `Future.successful(false)`,
- any unexpected error: `Future.failed`