### PR TITLE
Can log4j be replaced with slf4j ?

### DIFF
--- a/driver/src/main/scala/api/api.scala
+++ b/driver/src/main/scala/api/api.scala
@@ -39,7 +39,7 @@ import reactivemongo.core.protocol.{
 }
 import reactivemongo.core.commands.SuccessfulAuthentication
 import reactivemongo.api.commands.WriteConcern
-import reactivemongo.utils.LazyLogger
+import reactivemongo.util.LazyLogger
 
 /**
  * A helper that sends the given message to the given actor,

--- a/driver/src/main/scala/api/collections/bson/bsoncollection.scala
+++ b/driver/src/main/scala/api/collections/bson/bsoncollection.scala
@@ -91,7 +91,7 @@ case class BSONQueryBuilder(
     commentString: Option[String] = None,
     options: QueryOpts = QueryOpts(),
     maxTimeMsOption: Option[Long] = None) extends GenericQueryBuilder[BSONSerializationPack.type] {
-  import reactivemongo.utils.option
+  import reactivemongo.util.option
 
   type Self = BSONQueryBuilder
   val pack = BSONSerializationPack

--- a/driver/src/main/scala/api/commands/bson/count.scala
+++ b/driver/src/main/scala/api/commands/bson/count.scala
@@ -2,23 +2,33 @@ package reactivemongo.api.commands.bson
 
 import reactivemongo.api.BSONSerializationPack
 import reactivemongo.api.commands._
-import reactivemongo.bson._
-import reactivemongo.utils.option
+import reactivemongo.util.option
 
 object BSONCountCommand extends CountCommand[BSONSerializationPack.type] {
   val pack = BSONSerializationPack
 }
 
 object BSONCountCommandImplicits {
-  import BSONCountCommand._
-  implicit object HintWriter extends BSONWriter[Hint, BSONValue] {
-    def write(hint: Hint): BSONValue =
-      hint match {
-        case HintString(s)     => BSONString(s)
-        case HintDocument(doc) => doc
-      }
+  import reactivemongo.bson.{
+    BSONDocument,
+    BSONDocumentWriter,
+    BSONNumberLike,
+    BSONString,
+    BSONValue,
+    BSONWriter
   }
-  implicit object CountWriter extends BSONDocumentWriter[ResolvedCollectionCommand[Count]] {
+  import BSONCountCommand._
+
+  implicit object HintWriter extends BSONWriter[Hint, BSONValue] {
+    def write(hint: Hint): BSONValue = hint match {
+      case HintString(s)     => BSONString(s)
+      case HintDocument(doc) => doc
+    }
+  }
+
+  implicit object CountWriter
+      extends BSONDocumentWriter[ResolvedCollectionCommand[Count]] {
+
     def write(count: ResolvedCollectionCommand[Count]): BSONDocument =
       BSONDocument(
         "count" -> count.collection,
@@ -28,7 +38,9 @@ object BSONCountCommandImplicits {
         "hint" -> count.command.hint)
   }
 
-  implicit object CountResultReader extends DealingWithGenericCommandErrorsReader[CountResult] {
+  implicit object CountResultReader
+      extends DealingWithGenericCommandErrorsReader[CountResult] {
+
     def readResult(doc: BSONDocument): CountResult =
       CountResult(doc.getAs[BSONNumberLike]("n").map(_.toInt).getOrElse(0))
 

--- a/driver/src/main/scala/api/cursor.scala
+++ b/driver/src/main/scala/api/cursor.scala
@@ -19,9 +19,10 @@ import play.api.libs.iteratee._
 import reactivemongo.core.iteratees.{ CustomEnumeratee, CustomEnumerator }
 import reactivemongo.core.netty.BufferSequence
 import reactivemongo.core.protocol._
-import reactivemongo.utils.ExtendedFutures.DelayedFuture
-import reactivemongo.utils.LazyLogger
-import scala.annotation.tailrec
+import reactivemongo.util.{
+  ExtendedFutures,
+  LazyLogger
+}, ExtendedFutures.DelayedFuture
 import scala.collection.generic.CanBuildFrom
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success, Try }
@@ -383,7 +384,7 @@ object DefaultCursor {
       enumerateResponses(maxDocs, stopOnError) &> Enumeratee.map(makeIterator)
 
     def enumerate(maxDocs: Int = Int.MaxValue, stopOnError: Boolean = false)(implicit ctx: ExecutionContext): Enumerator[A] = {
-      @tailrec
+      @annotation.tailrec
       def next(it: Iterator[A], stopOnError: Boolean): Option[Try[A]] = {
         if (it.hasNext) {
           val tried = Try(it.next)

--- a/driver/src/main/scala/api/indexes.scala
+++ b/driver/src/main/scala/api/indexes.scala
@@ -19,7 +19,6 @@ import reactivemongo.core.protocol.MongoWireVersion
 import reactivemongo.api._
 import reactivemongo.bson._
 import reactivemongo.api.commands.{ DropIndexes, LastError, WriteResult }
-import reactivemongo.utils.option
 import scala.concurrent.{ Future, ExecutionContext }
 
 /** Type of Index */
@@ -438,6 +437,8 @@ object CollectionIndexesManager {
 }
 
 object IndexesManager {
+  import reactivemongo.util.option
+
   /**
    * Returns an indexes manager for specified database.
    *

--- a/driver/src/main/scala/core/actors.scala
+++ b/driver/src/main/scala/core/actors.scala
@@ -23,7 +23,7 @@ import org.jboss.netty.channel.group.{
   ChannelGroupFutureListener,
   DefaultChannelGroup
 }
-import reactivemongo.utils.LazyLogger
+import reactivemongo.util.LazyLogger
 import reactivemongo.core.errors.{ DriverException, GenericDriverException }
 import reactivemongo.core.protocol.{
   CheckedWriteRequest,
@@ -212,7 +212,7 @@ trait MongoDBSystem extends Actor {
     val remainingConnections = nodeSet.nodes.foldLeft(0)(
       { (open, node) => open + node.connections.size })
 
-    if (logger.logger.isDebugEnabled()) {
+    if (logger.isDebugEnabled) {
       val disconnected = nodeSet.nodes.foldLeft(0) { (open, node) =>
         open + node.connections.count(_.status == ConnectionStatus.Disconnected)
       }
@@ -262,7 +262,7 @@ trait MongoDBSystem extends Actor {
     case msg @ ChannelDisconnected(channelId) => {
       updateNodeSetOnDisconnect(channelId)
 
-      if (logger.logger.isDebugEnabled()) {
+      if (logger.isDebugEnabled) {
         val remainingConnections = nodeSet.nodes.foldLeft(0) { (open, node) =>
           open + node.connections.size
         }

--- a/driver/src/main/scala/core/commands/commands.scala
+++ b/driver/src/main/scala/core/commands/commands.scala
@@ -34,7 +34,7 @@ import reactivemongo.bson.exceptions.DocumentKeyNotFound
 import reactivemongo.core.errors.{ DatabaseException, ReactiveMongoException }
 import reactivemongo.core.protocol.{ RequestMaker, Query, QueryFlags, Response }
 import reactivemongo.core.netty._
-import reactivemongo.utils.option
+import reactivemongo.util.option
 import reactivemongo.core.nodeset.NodeStatus
 
 @deprecated("consider using reactivemongo.api.commands instead", "0.11.0")

--- a/driver/src/main/scala/core/nodeset.scala
+++ b/driver/src/main/scala/core/nodeset.scala
@@ -15,7 +15,7 @@ import org.jboss.netty.channel.{
 
 import akka.actor.ActorRef
 
-import reactivemongo.utils.LazyLogger
+import reactivemongo.util.LazyLogger
 import reactivemongo.core.protocol.Request
 
 import reactivemongo.bson.BSONDocument

--- a/driver/src/main/scala/core/protocol/protocol.scala
+++ b/driver/src/main/scala/core/protocol/protocol.scala
@@ -30,7 +30,7 @@ import reactivemongo.api.SerializationPack
 import reactivemongo.api.commands.GetLastError
 import reactivemongo.core.errors._
 import reactivemongo.core.netty._
-import reactivemongo.utils.LazyLogger
+import reactivemongo.util.LazyLogger
 import BufferAccessors._
 import reactivemongo.api.ReadPreference
 

--- a/driver/src/main/scala/util/LazyLogger.scala
+++ b/driver/src/main/scala/util/LazyLogger.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2012-2013 Stephane Godbillon (@sgodbillon) and Zenexity
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactivemongo.util
+
+object LazyLogger {
+  import org.slf4j.{ LoggerFactory, Logger }
+
+  /**
+   * Returns the lazy logger matching the SLF4J `name`.
+   *
+   * @param name the logger name
+   */
+  def apply(name: String): LazyLogger =
+    new LazyLogger(LoggerFactory getLogger name)
+
+  final class LazyLogger(logger: Logger) {
+    def trace(s: => String) { if (logger.isTraceEnabled) logger.trace(s) }
+    def trace(s: => String, e: => Throwable) {
+      if (logger.isTraceEnabled) logger.trace(s, e)
+    }
+
+    lazy val isDebugEnabled = logger.isDebugEnabled
+    def debug(s: => String) { if (isDebugEnabled) logger.debug(s) }
+    def debug(s: => String, e: => Throwable) {
+      if (isDebugEnabled) logger.debug(s, e)
+    }
+
+    def info(s: => String) { if (logger.isInfoEnabled) logger.info(s) }
+    def info(s: => String, e: => Throwable) {
+      if (logger.isInfoEnabled) logger.info(s, e)
+    }
+
+    def warn(s: => String) { if (logger.isWarnEnabled) logger.warn(s) }
+    def warn(s: => String, e: => Throwable) {
+      if (logger.isWarnEnabled) logger.warn(s, e)
+    }
+
+    def error(s: => String) { if (logger.isErrorEnabled) logger.error(s) }
+    def error(s: => String, e: => Throwable) {
+      if (logger.isErrorEnabled) logger.error(s, e)
+    }
+  }
+}

--- a/driver/src/main/scala/util/package.scala
+++ b/driver/src/main/scala/util/package.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2012-2013 Stephane Godbillon (@sgodbillon) and Zenexity
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactivemongo
+
+package object util {
+  /** Makes an option of the value matching the condition. */
+  def option[T](cond: => Boolean, value: => T): Option[T] =
+    if (cond) Some(value) else None
+
+  import scala.concurrent.{
+    ExecutionContext,
+    Future,
+    Promise,
+    duration
+  }, duration.Duration
+
+  case class EitherMappableFuture[A](future: Future[A]) {
+    def mapEither[E <: Throwable, B](f: A => Either[E, B])(implicit ec: ExecutionContext) = {
+      future.flatMap(
+        f(_) match {
+          case Left(e)  => Future.failed(e)
+          case Right(b) => Future.successful(b)
+        })
+    }
+  }
+  object EitherMappableFuture {
+    implicit def futureToEitherMappable[A](future: Future[A]): EitherMappableFuture[A] = EitherMappableFuture(future)
+  }
+
+  object ExtendedFutures {
+    import akka.actor.ActorSystem
+
+    // better way to this?
+    def DelayedFuture(millis: Long, system: ActorSystem): Future[Unit] = {
+      implicit val ec = system.dispatcher
+      val promise = Promise[Unit]()
+      system.scheduler.scheduleOnce(Duration.apply(millis, "millis"))(promise.success(()))
+      promise.future
+    }
+  }
+}

--- a/driver/src/main/scala/utils.scala
+++ b/driver/src/main/scala/utils.scala
@@ -18,8 +18,10 @@ package reactivemongo.utils
 import scala.concurrent._
 import scala.concurrent.duration._
 
+@deprecated(message = "Use [[reactivemongo.util]]", since = "0.12.0")
 object `package` {
   /** Concats two array - fast way */
+  @deprecated(message = "Use array concat operation", since = "0.12.0")
   def concat[T](a1: Array[T], a2: Array[T])(implicit m: Manifest[T]): Array[T] = {
     var i, j = 0
     val result = new Array[T](a1.length + a2.length)
@@ -35,9 +37,12 @@ object `package` {
   }
 
   /** Makes an option of the value matching the condition. */
+  @deprecated(message = "Use [[reactivemongo.util.option]]", since = "0.12.0")
   def option[T](cond: => Boolean, value: => T): Option[T] = (if (cond) Some(value) else None)
 }
 
+@deprecated(
+  message = "Use [[reactivemongo.util.LazyLogger]]", since = "0.12.0")
 case class LazyLogger(logger: org.apache.logging.log4j.Logger) {
   def trace(s: => String) { if (logger.isTraceEnabled) logger.trace(s) }
   def trace(s: => String, e: => Throwable) { if (logger.isTraceEnabled) logger.trace(s, e) }
@@ -51,10 +56,15 @@ case class LazyLogger(logger: org.apache.logging.log4j.Logger) {
   def error(s: => String, e: => Throwable) { if (logger.isErrorEnabled) logger.error(s, e) }
 }
 
+@deprecated(
+  message = "Use [[reactivemongo.util.LazyLogger]]", since = "0.12.0")
 object LazyLogger {
-  def apply(logger: String): LazyLogger = LazyLogger(org.apache.logging.log4j.LogManager.getLogger(logger))
+  def apply(logger: String): LazyLogger =
+    LazyLogger(org.apache.logging.log4j.LogManager.getLogger(logger))
 }
 
+@deprecated(
+  message = "Use [[reactivemongo.util.EitherMappableFuture]]", since = "0.12.0")
 case class EitherMappableFuture[A](future: Future[A]) {
   def mapEither[E <: Throwable, B](f: A => Either[E, B])(implicit ec: ExecutionContext) = {
     future.flatMap(
@@ -64,10 +74,15 @@ case class EitherMappableFuture[A](future: Future[A]) {
       })
   }
 }
+
+@deprecated(
+  message = "Use [[reactivemongo.util.EitherMappableFuture]]", since = "0.12.0")
 object EitherMappableFuture {
   implicit def futureToEitherMappable[A](future: Future[A]): EitherMappableFuture[A] = EitherMappableFuture(future)
 }
 
+@deprecated(
+  message = "Use [[reactivemongo.util.ExtendedFutures]]", since = "0.12.0")
 object ExtendedFutures {
   import akka.actor.{ ActorSystem, Scheduler }
 

--- a/driver/src/test/scala/CollectionSpec.scala
+++ b/driver/src/test/scala/CollectionSpec.scala
@@ -22,7 +22,7 @@ object CollectionSpec extends Specification with Tags {
 
     "check if it's capped" in {
       // convertToCapped is async. Let's wait a little while before checking if it's done
-      Await.result(reactivemongo.utils.ExtendedFutures.DelayedFuture(4000, connection.actorSystem), timeout)
+      Await.result(reactivemongo.util.ExtendedFutures.DelayedFuture(4000, connection.actorSystem), timeout)
       println("\n\n\t***** CHECKING \n\n")
       val stats = Await.result(collection.stats, timeout)
       println(stats)

--- a/project/ReactiveMongo.scala
+++ b/project/ReactiveMongo.scala
@@ -140,8 +140,11 @@ object Dependencies {
 
   val specs = "org.specs2" %% "specs2-core" % "2.4.9" % Test
 
-  val log4jVersion = "2.0.2"
-  val log4j = Seq("org.apache.logging.log4j" % "log4j-api" % log4jVersion, "org.apache.logging.log4j" % "log4j-core" % log4jVersion)
+  val logApiVersion = "1.7.12"
+  val logApi = Seq(
+    "org.slf4j" % "slf4j-api" % logApiVersion % "provided",
+    "org.apache.logging.log4j" % "log4j-api" % "2.0.2" // deprecated
+  )
 
   val shapelessTest = "com.chuusai" % "shapeless" % "2.0.0" %
   Test cross CrossVersion.binaryMapped {
@@ -179,7 +182,7 @@ object ReactiveMongoBuild extends Build {
         iteratees,
         commonsCodec,
         shapelessTest,
-        specs) ++ log4j,
+        specs) ++ logApi,
       testOptions in Test += Tests.Cleanup(cl => {
         import scala.language.reflectiveCalls
         val c = cl.loadClass("Common$")


### PR DESCRIPTION
Hi,
first of all, thank you, Pascal and Stephane, for great work on reactive driver. 

But I'd like to rise a question about logging system. I see that currently it's log4j-2. But reactivemongo also has a hard dependency on Akka, which basically agnostic of logging system via slf4j. Is it currently planned to move towards slf4j?
