### PR TITLE
Move Iteratee support as a separate module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 scala:
 - 2.11.6
-- 2.10.4
+- 2.10.5
 jdk:
 - oraclejdk7
 - openjdk7

--- a/bson/src/test/scala/Serialization.scala
+++ b/bson/src/test/scala/Serialization.scala
@@ -29,7 +29,7 @@ class SerializationSpecs extends Specification {
     if (Arrays.equals(a1, a2)) {
       success
     } else {
-      println(s"\texpected:\n${Arrays.toString(a1)},\n\tgot:\n${Arrays.toString(a2)}")
+      //println(s"\texpected:\n${Arrays.toString(a1)},\n\tgot:\n${Arrays.toString(a2)}")
       failure
     }
   }
@@ -80,29 +80,36 @@ class SerializationSpecs extends Specification {
           "adress" -> BSONString("coucou")),
         "lastSeen" -> BSONLong(1360512704747L))
       val buffer = new ArrayBSONBuffer
-      DefaultBufferHandler.write(buffer, doc)*/
+       DefaultBufferHandler.write(buffer, doc)*/
+
       def listAll[A <: ReadableBuffer](buf: LowLevelBsonDocReader[A], spaces: Int = 0): Unit = {
         //val buf = new LowLevelBsonDocReader(b)
         buf.fieldStream.map { f =>
-          print(" " * spaces)
+          //print(" " * spaces)
+
           f match {
             case StructureField(_, _, b) =>
-              println(f.name)
+              //println(f.name)
               listAll(b, spaces + 2)
             case LazyField(tpe, _, b) =>
-              if (tpe == 0x02 || tpe == 0x0D || tpe == 0x0E)
-                println(s"${f.name} -> ${b.readString}")
-              else if (tpe == 0x05) {
+              if (tpe == 0x02 || tpe == 0x0D || tpe == 0x0E) {
+                //println(s"${f.name} -> ${b.readString}")
+              } else if (tpe == 0x05) {
                 val length = b.readInt
                 val subtype = b.readByte
-                println(s"l=$length, subtype=$subtype, readable=${b.readable}")
+                //println(s"l=$length, subtype=$subtype, readable=${b.readable}")
                 val contents = b.readArray(length)
-                println(s"${f.name} -> binary (l=$length, subtype=$subtype, hex=${utils.Converters.hex2Str(contents)} contents=${contents.mkString(", ")})")
-              } else println(s"${f.name} -> <${b.readable} bytes>")
-            case v: ValueField[_] =>
-              println(s"${f.name} -> ${v.value}")
-            case NoValue(tpe, _) =>
-              println(s"${f.name} -> <singleton $tpe>")
+                //println(s"${f.name} -> binary (l=$length, subtype=$subtype, hex=${utils.Converters.hex2Str(contents)} contents=${contents.mkString(", ")})")
+              } else {
+                //println(s"${f.name} -> <${b.readable} bytes>")
+              }
+            case v: ValueField[_] => {
+              //println(s"${f.name} -> ${v.value}")
+            }
+
+            case NoValue(tpe, _) => {
+              //println(s"${f.name} -> <singleton $tpe>")
+            }
           }
           //if(f.tpe == 0x03 || f.tpe == 0x04)
           //  listAll(f.value, spaces + 2)
@@ -207,9 +214,7 @@ class SerializationSpecs extends Specification {
     "deserialize a complex document" in {
       val buffer = ArrayReadableBuffer(expectedWholeDocumentBytes)
       val doc = DefaultBufferHandler.readDocument(buffer)
-      doc.recover {
-        case e => e.printStackTrace()
-      }
+
       doc.isSuccess mustEqual true
     }
   }

--- a/driver/src/main/scala/api/QueryOpts.scala
+++ b/driver/src/main/scala/api/QueryOpts.scala
@@ -29,32 +29,38 @@ object SortOrder {
 
 /**
  * A helper to make the query options.
- *
  * You may use the methods to set the fields of this class, or set them directly.
  *
- * @param skipN The number of documents to skip.
- * @param batchSizeN The upper limit on the number of documents to retrieve per batch.
- * @param flagsN The query flags.
+ * @param skipN the number of documents to skip.
+ * @param batchSizeN the upper limit on the number of documents to retrieve per batch.
+ * @param flagsN the query flags
  */
 case class QueryOpts(
     skipN: Int = 0,
     batchSizeN: Int = 0,
     flagsN: Int = 0) {
+
   /** Sets the number of documents to skip. */
   def skip(n: Int) = copy(skipN = n)
+
   /** Sets an upper limit on the number of documents to retrieve per batch. Defaults to 0 (meaning no upper limit - MongoDB decides). */
   def batchSize(n: Int) = copy(batchSizeN = n)
+
   /** Sets the query flags. */
   def flags(n: Int) = copy(flagsN = n)
 
   /** Toggles TailableCursor: Makes the cursor not to close after all the data is consumed. */
   def tailable = copy(flagsN = flagsN ^ QueryFlags.TailableCursor)
+
   /** Toggles SlaveOk: The query is might be run on a secondary. */
   def slaveOk = copy(flagsN = flagsN ^ QueryFlags.SlaveOk)
+
   /** Toggles OplogReplay */
   def oplogReplay = copy(flagsN = flagsN ^ QueryFlags.OplogReplay)
+
   /** Toggles NoCursorTimeout: The cursor will not expire automatically */
   def noCursorTimeout = copy(flagsN = flagsN ^ QueryFlags.NoCursorTimeout)
+
   /**
    * Toggles AwaitData: Block a little while waiting for more data instead of returning immediately if no data.
    * Use along with TailableCursor.

--- a/driver/src/main/scala/api/collection.scala
+++ b/driver/src/main/scala/api/collection.scala
@@ -182,7 +182,7 @@ trait CollectionMetaCommands {
     import BSONDropCollectionImplicits._
 
     Command.run(BSONSerializationPack)(self, DropCollection).flatMap {
-      case DropCollectionResult(false) if (failIfNotFound) =>
+      case DropCollectionResult(false) if failIfNotFound =>
         Future.failed[Boolean](GenericDatabaseException(
           s"fails to drop collection: $name", Some(26)))
 

--- a/driver/src/main/scala/api/collections/genericcollection.scala
+++ b/driver/src/main/scala/api/collections/genericcollection.scala
@@ -258,6 +258,7 @@ trait GenericCollection[P <: SerializationPack with Singleton] extends Collectio
     }
     val metadata = db.connection.metadata
     if (!documents.isEmpty) {
+      // TODO: Await maxTimeout?
       val havingMetadata = Failover2(db.connection, failoverStrategy) { () =>
         metadata.map(Future.successful).getOrElse(Future.failed(ConnectionNotInitialized.MissingMetadata))
       }.future
@@ -298,6 +299,7 @@ trait GenericCollection[P <: SerializationPack with Singleton] extends Collectio
    * @return a future [[reactivemongo.api.commands.WriteResult]] that can be used to check whether the insertion was successful.
    */
   def insert[T](document: T, writeConcern: WriteConcern = defaultWriteConcern)(implicit writer: pack.Writer[T], ec: ExecutionContext): Future[WriteResult] = {
+    // TODO: Await maxTimeout
     Failover2(db.connection, failoverStrategy) { () =>
       db.connection.metadata match {
         case Some(metadata) if metadata.maxWireVersion >= MongoWireVersion.V26 =>
@@ -342,6 +344,7 @@ trait GenericCollection[P <: SerializationPack with Singleton] extends Collectio
    * @return a future [[reactivemongo.api.commands.WriteResult]] that can be used to check whether the update was successful.
    */
   def update[S, U](selector: S, update: U, writeConcern: WriteConcern = defaultWriteConcern, upsert: Boolean = false, multi: Boolean = false)(implicit selectorWriter: pack.Writer[S], updateWriter: pack.Writer[U], ec: ExecutionContext): Future[UpdateWriteResult] = Failover2(db.connection, failoverStrategy) { () =>
+    // TODO: Await maxTimeout
     db.connection.metadata match {
       case Some(metadata) if (
         metadata.maxWireVersion >= MongoWireVersion.V26) => {
@@ -587,6 +590,7 @@ trait GenericCollection[P <: SerializationPack with Singleton] extends Collectio
    */
   def remove[T](query: T, writeConcern: WriteConcern = defaultWriteConcern, firstMatchOnly: Boolean = false)(implicit writer: pack.Writer[T], ec: ExecutionContext): Future[WriteResult] =
     Failover2(db.connection, failoverStrategy) { () =>
+      // TODO: Await maxTimeout
       db.connection.metadata match {
         case Some(metadata) if (
           metadata.maxWireVersion >= MongoWireVersion.V26) => {

--- a/driver/src/main/scala/api/commands/commands.scala
+++ b/driver/src/main/scala/api/commands/commands.scala
@@ -113,6 +113,7 @@ object Command {
       val (requestMaker, mongo26WriteCommand) =
         buildRequestMaker(pack)(command, writer, readPreference, db.name)
 
+      // TODO: Await maxTimeout?
       Failover2(db.connection, failover) { () =>
         db.connection.sendExpectingResponse(
           requestMaker, mongo26WriteCommand).map { response =>
@@ -170,7 +171,7 @@ object Command {
         ResolvedCollectionCommand(collection.name, command), failover).cursor[R]
 
       for {
-        firstResponse <- cursor.makeRequest
+        firstResponse <- cursor.makeRequest(cursor.numberToReturn)
         result <- cursor.headOption.flatMap(_.fold(Future.failed[R](
           ReactiveMongoException("missing result")))(Future.successful(_)))
       } yield ResponseResult(firstResponse, cursor.numberToReturn, result)

--- a/driver/src/main/scala/api/database.scala
+++ b/driver/src/main/scala/api/database.scala
@@ -91,12 +91,14 @@ sealed trait DB {
   /** Authenticates the connection on this database. */
   def authenticate(user: String, password: String)(implicit timeout: FiniteDuration): Future[SuccessfulAuthentication] = connection.authenticate(name, user, password)
 
-  /** Returns the database of the given name on the same MongoConnection. */
-  @deprecated("Consider using `sibling` instead", "0.10")
-  def sister(name: String, failoverStrategy: FailoverStrategy = failoverStrategy)(implicit ec: ExecutionContext): DefaultDB = sibling(name, failoverStrategy)
+  /**
+   * Returns the database of the given name on the same MongoConnection.
+   * @see [[sibling1]]
+   */
+  def sibling(name: String, failoverStrategy: FailoverStrategy = failoverStrategy)(implicit ec: ExecutionContext): DefaultDB = connection(name, failoverStrategy)
 
   /** Returns the database of the given name on the same MongoConnection. */
-  def sibling(name: String, failoverStrategy: FailoverStrategy = failoverStrategy)(implicit ec: ExecutionContext): DefaultDB = connection.db(name, failoverStrategy)
+  def sibling1(name: String, failoverStrategy: FailoverStrategy = failoverStrategy)(implicit ec: ExecutionContext): Future[DefaultDB] = connection.database(name, failoverStrategy)
 
 }
 

--- a/driver/src/main/scala/core/actors.scala
+++ b/driver/src/main/scala/core/actors.scala
@@ -868,7 +868,10 @@ private[actors] case class AwaitingResponse(
   isGetLastError: Boolean,
   isMongo26WriteOp: Boolean)
 
-/** A message to send to a MonitorActor to be warned when a primary has been discovered. */
+/**
+ * A message to send to a MonitorActor to be warned when a primary has been discovered.
+ */
+@deprecated(message = "Wil be removed", since = "0.11.10")
 case object WaitForPrimary
 
 // exceptions

--- a/driver/src/main/scala/core/errors.scala
+++ b/driver/src/main/scala/core/errors.scala
@@ -25,7 +25,7 @@ trait ReactiveMongoException extends Exception {
   /** explanation message */
   def message: String
 
-  override def getMessage: String = "MongoError['" + message + "']"
+  override def getMessage: String = s"MongoError['$message']"
 }
 
 object ReactiveMongoException {

--- a/driver/src/main/scala/core/protocol/protocol.scala
+++ b/driver/src/main/scala/core/protocol/protocol.scala
@@ -348,6 +348,7 @@ private[reactivemongo] class RequestEncoder extends OneToOneEncoder {
 
 object ReplyDocumentIterator {
   def apply[P <: SerializationPack, A](pack: P)(reply: Reply, buffer: ChannelBuffer)(implicit reader: pack.Reader[A]): Iterator[A] = new Iterator[A] {
+    override val isTraversableAgain = false // TODO: Add test
     override def hasNext = buffer.readable
     override def next =
       try {

--- a/driver/src/test/scala/AggregationSpec.scala
+++ b/driver/src/test/scala/AggregationSpec.scala
@@ -90,12 +90,10 @@ object AggregationSpec extends org.specs2.mutable.Specification {
             await(timeoutMillis)
         }
 
-        /* TODO: (after cursor fix)
         "with limit (maxDocs)" in {
           collect(2) aka "cursor result" must beEqualTo(expected take 2).
             await(timeoutMillis)
         }
-         */
       }
     }
 

--- a/driver/src/test/scala/CollectionSpec.scala
+++ b/driver/src/test/scala/CollectionSpec.scala
@@ -66,7 +66,7 @@ object CollectionSpec extends Specification with Tags {
     } tag ("testCommands")*/
 
     "drop it" in {
-      collection.drop() must beEqualTo(()).await(timeoutMillis)
+      collection.drop(false) must beTrue.await(timeoutMillis)
     }
   }
 }

--- a/driver/src/test/scala/CommonUseCases.scala
+++ b/driver/src/test/scala/CommonUseCases.scala
@@ -1,5 +1,4 @@
 import org.specs2.mutable._
-import play.api.libs.iteratee.Enumerator
 import reactivemongo.api._
 import reactivemongo.bson._
 import reactivemongo.api.commands.bson.BSONCountCommand._
@@ -16,8 +15,9 @@ class CommonUseCases extends Specification {
 
   "ReactiveMongo" should {
     "create a collection" in {
-      Await.result(collection.create(), timeout) mustEqual (())
+      collection.create() must beEqualTo({}).await(timeoutMillis)
     }
+
     // TODO !!!
     /*
     "insert some docs from an enumerator of docs" in {
@@ -29,37 +29,54 @@ class CommonUseCases extends Specification {
       val enum = Enumerator[BSONDocument]()
       Await.result(collection.bulkInsert(enum, 100), timeout) mustEqual 0
     }*/
+
     "insert some docs from a seq of docs" in {
-      val docs = (18 to 60).toStream.map(i => BSONDocument("age" -> BSONInteger(i), "name" -> BSONString("Jack" + i)))
-      val result = Await.result(collection.bulkInsert(docs, ordered = true), timeout)
-      Await.result(collection.runValueCommand(Count(BSONDocument("age" -> BSONDocument("$gte" -> 18, "$lte" -> 60)))), timeout) mustEqual 43
+      val docs = (18 to 60).toStream.map(i => BSONDocument(
+        "age" -> BSONInteger(i), "name" -> BSONString("Jack" + i)))
+
+      (for {
+        result <- collection.bulkInsert(docs, ordered = true)
+        count <- collection.runValueCommand(Count(BSONDocument(
+          "age" -> BSONDocument("$gte" -> 18, "$lte" -> 60))))
+      } yield count) must beEqualTo(43).await(timeoutMillis)
     }
+
     "insert from an empty enumerator of docs" in {
       val docs = Stream.empty[BSONDocument]
-      val result = Await.result(collection.bulkInsert(docs, ordered = true), timeout)
-      result.n mustEqual 0
+
+      collection.bulkInsert(docs, ordered = true).map(_.n) must beEqualTo(0).
+        await(timeoutMillis)
     }
+
     "find them" in {
       // batchSize (>1) allows us to test cursors ;)
       val it = collection.find(BSONDocument()).options(QueryOpts().batchSize(2)).cursor[BSONDocument]()
       Await.result(it.collect[List](), timeout).map(_.getAs[BSONInteger]("age").get.value).mkString("") mustEqual (18 to 60).mkString("")
     }
+
     "find by regexp" in {
-      Await.result(collection.find(BSONDocument("name" -> BSONRegex("ack2", ""))).cursor[BSONDocument]().collect[List](), timeout).size mustEqual 10
+      collection.find(BSONDocument("name" -> BSONRegex("ack2", ""))).
+        cursor[BSONDocument]().collect[List]().map(_.size).
+        aka("size") must beEqualTo(10).await(timeoutMillis)
     }
+
     "find by regexp with flag" in {
-      val q =
+      val query =
         BSONDocument(
           "$or" -> BSONArray(
             BSONDocument("name" -> BSONRegex("^jack2", "i")),
             BSONDocument("name" -> BSONRegex("^jack3", "i"))))
-      Await.result(collection.find(q).cursor[BSONDocument]().collect[List](), timeout).size mustEqual 20
+
+      collection.find(query).cursor[BSONDocument]().collect[List]().
+        map(_.size) aka "size" must beEqualTo(20).await(timeoutMillis)
     }
+
     "find them with a projection" in {
       val pjn = BSONDocument("name" -> BSONInteger(1), "age" -> BSONInteger(1), "something" -> BSONInteger(1))
       val it = collection.find(BSONDocument(), pjn).options(QueryOpts().batchSize(2)).cursor[BSONDocument]()
       Await.result(it.collect[List](), timeout).map(_.getAs[BSONInteger]("age").get.value).mkString("") mustEqual (18 to 60).mkString("")
     }
+
     "insert a document containing a merged array of objects, fetch and check it" in {
       val array = BSONArray(
         BSONDocument(
@@ -86,22 +103,24 @@ class CommonUseCases extends Specification {
       }.mkString(",")
       contactsString mustEqual "telephone:+331234567890,mail:joe@plop.com"
     }
+
     "insert a weird doc" in {
       val doc = BSONDocument("coucou" -> BSONString("coucou"), "plop" -> BSONInteger(1), "plop" -> BSONInteger(2))
-      val result = Await.result(collection.insert(doc), timeout)
-      println("\n" + result + "\n")
-      result.ok mustEqual true
+
+      collection.insert(doc).map(_.ok) must beTrue.await(timeoutMillis)
     }
+
     "find this weird doc" in {
-      val doc = Await.result(collection.find(BSONDocument("coucou" -> BSONString("coucou"))).one[BSONDocument], timeout)
-      println("\n" + doc.map(BSONDocument.pretty(_)) + "\n")
-      doc.isDefined mustEqual true
+      collection.find(BSONDocument("coucou" -> BSONString("coucou"))).
+        one[BSONDocument] must beSome.await(timeoutMillis)
     }
+
     "fail with this error" in {
-      val query = BSONDocument("$and" -> BSONDocument("name" -> BSONString("toto")))
-      val future = collection.find(query).one[BSONDocument]
-      Await.ready(future, timeout)
-      (future.value.get match { case Failure(e) => e.printStackTrace(); true; case _ => false }) mustEqual true
+      val query = BSONDocument("$and" ->
+        BSONDocument("name" -> BSONString("toto")))
+
+      Await.result(collection.find(query).one[BSONDocument], timeout).
+        aka("findOne") must throwA[Exception]
     }
   }
 }

--- a/driver/src/test/scala/CursorSpec.scala
+++ b/driver/src/test/scala/CursorSpec.scala
@@ -1,11 +1,10 @@
-import org.specs2.mutable._
-import reactivemongo.bson._
-import DefaultBSONHandlers._
-
 import scala.concurrent.{ Await, Future }
-import scala.concurrent.duration._
+import scala.concurrent.duration.DurationInt
+
 import play.api.libs.iteratee.Iteratee
 
+import reactivemongo.bson._
+import reactivemongo.core.protocol.Response
 import reactivemongo.core.errors.DetailedDatabaseException
 import reactivemongo.api.{
   Cursor,
@@ -13,10 +12,13 @@ import reactivemongo.api.{
   CursorProducer,
   DB,
   QueryOpts,
+  MongoDriver,
   WrappedCursor
 }
 
-object CursorSpec extends Specification {
+object CursorSpec extends org.specs2.mutable.Specification {
+  "Cursor" title
+
   sequential
 
   import Common._
@@ -26,26 +28,71 @@ object CursorSpec extends Specification {
   "ReactiveMongo" should {
     "insert 16,517 records" in {
       val futs = for (i <- 0 until 16517)
-        yield coll.insert(BSONDocument("i" -> BSONInteger(i), "record" -> BSONString("record" + i)))
-      val fut = Future.sequence(futs)
-      Await.result(fut, DurationInt(20).seconds)
-      println("inserted 16,517 records")
-      success
-    }
+        yield coll.insert(BSONDocument(
+        "i" -> BSONInteger(i), "record" -> BSONString("record" + i)))
 
-    "get all the 16,517 documents" in {
-      var i = 0
-      val future = coll.find(BSONDocument()).cursor().enumerate() |>>> (Iteratee.foreach({ e =>
-        //println(s"doc $i => $e")
-        i += 1
-      }))
-
-      future.map(_ => i) must beEqualTo(16517).await(21000 /*21s*/ )
+      Future.sequence(futs).map { _ =>
+        println("inserted 16,517 records")
+      } aka "fixtures" must beEqualTo({}).await(timeoutMillis)
     }
 
     "get 10 first docs" in {
-      coll.find(BSONDocument()).cursor().collect[List](10).map(_.size).
+      coll.find(BSONDocument.empty).cursor().collect[List](10).map(_.size).
         aka("result size") must beEqualTo(10).await(timeoutMillis)
+    }
+
+    "fold" >> {
+      "all the documents" in {
+        coll.find(BSONDocument.empty).cursor().fold(0)((st, _) => st + 1).
+          aka("result size") must beEqualTo(16517).await(timeoutMillis)
+      }
+
+      "only 1024 documents" in {
+        coll.find(BSONDocument.empty).cursor().fold(0, 1024)((st, _) => st + 1).
+          aka("result size") must beEqualTo(1024).await(timeoutMillis)
+      }
+    }
+
+    "fold while successful" >> {
+      "all the documents" in {
+        coll.find(BSONDocument.empty).cursor().foldWhile(0)(
+          (st, _) => Cursor.Cont(st + 1)).
+          aka("result size") must beEqualTo(16517).await(timeoutMillis)
+      }
+
+      "only 1024 documents" in {
+        coll.find(BSONDocument.empty).cursor().foldWhile(0, 1024)(
+          (st, _) => Cursor.Cont(st + 1)).
+          aka("result size") must beEqualTo(1024).await(timeoutMillis)
+      }
+    }
+
+    "fold the bulks" >> {
+      "for all the documents" in {
+        coll.find(BSONDocument.empty).cursor().foldBulks(0)(
+          (st, bulk) => Cursor.Cont(st + bulk.size)).
+          aka("result size") must beEqualTo(16517).await(timeoutMillis)
+      }
+
+      "for 1024 documents" in {
+        coll.find(BSONDocument.empty).cursor().foldBulks(0, 1024)(
+          (st, bulk) => Cursor.Cont(st + bulk.size)).
+          aka("result size") must beEqualTo(1024).await(timeoutMillis)
+      }
+    }
+
+    "fold the responses" >> {
+      "for all the documents" in {
+        coll.find(BSONDocument.empty).cursor().foldResponses(0)(
+          (st, resp) => Cursor.Cont(st + resp.reply.numberReturned)).
+          aka("result size") must beEqualTo(16517).await(timeoutMillis)
+      }
+
+      "for 1024 documents" in {
+        coll.find(BSONDocument.empty).cursor().foldResponses(0, 1024)(
+          (st, resp) => Cursor.Cont(st + resp.reply.numberReturned)).
+          aka("result size") must beEqualTo(1024).await(timeoutMillis)
+      }
     }
 
     "produce a custom cursor for the results" in {
@@ -59,55 +106,602 @@ object CursorSpec extends Specification {
           new FlattenedFooCursor(future)
       }
 
-      val cursor = coll.find(BSONDocument()).cursor()
+      val cursor = coll.find(BSONDocument.empty).cursor()
 
       cursor.foo must_== "Bar" and (
         Cursor.flatten(Future.successful(cursor)).foo must_== "raB")
     }
 
-    "throws exception when maxTimeout reached" in {
+    "throw exception when maxTimeout reached" in {
       val futs = for (i <- 0 until 16517)
-        yield coll.insert(BSONDocument("i" -> BSONInteger(i), "record" -> BSONString("record" + i)))
+        yield coll.insert(BSONDocument(
+        "i" -> BSONInteger(i), "record" -> BSONString("record" + i)))
+
       val fut = Future.sequence(futs)
       Await.result(fut, DurationInt(20).seconds)
-      println("inserted 16,517 records")
 
-      val fut2 = coll.find(BSONDocument("record" -> "asd")).maxTimeMs(1).cursor().collect[List](10)
-      fut2 must throwA[DetailedDatabaseException].await(timeout = DurationInt(1).seconds)
-    }
-  }
-
-  "BSON Cursor" should {
-    object IdReader extends BSONDocumentReader[Int] {
-      def read(doc: BSONDocument): Int = doc.getAs[Int]("id").get
+      coll.find(BSONDocument("record" -> "asd")).maxTimeMs(1).cursor().
+        collect[List](10) must throwA[DetailedDatabaseException].
+        await(timeout = DurationInt(1).seconds)
     }
 
-    val expectedList = List(9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
-    @inline def toList =
-      Iteratee.fold[Int, List[Int]](List.empty[Int]) { (l, i) => i :: l }
+    "stop on error" >> {
+      val drv = new MongoDriver
+      def con = drv.connection(List("localhost:27017"), DefaultOptions)
+      def scol(n: String = coll.name) = Await.result(for {
+        d <- con.database(db.name)
+        c <- d.coll(n)
+      } yield c, timeout)
 
-    "read from collection" >> {
-      def collection(n: String) = {
-        val col = db(s"somecollection_$n")
+      "when folding responses" >> {
+        "if fails while processing with existing documents" in {
+          var count = 0
+          def onError(last: Unit, e: Throwable): Unit = { count = count + 1 }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).cursor()
 
-        Future.sequence((0 until 10) map { id =>
-          col.insert(BSONDocument("id" -> id))
-        }) map { _ =>
-          //println(s"-- all documents inserted in test collection $n")
-          col
+          cursor.foldResponses({}, 128)(
+            { (_, _) => sys.error("Foo"): Cursor.State[Unit] },
+            Cursor.FailOnError[Unit](onError)).recover({ case _ => count }).
+            aka("folding") must beEqualTo(1).await(timeoutMillis)
+        }
+
+        "if fails while processing w/o documents" in {
+          var count = 0
+          def onError(last: Unit, e: Throwable): Unit = { count = count + 1 }
+          val c = scol(System.identityHashCode(onError _).toString)
+          val cursor = c.find(BSONDocument.empty).cursor()
+
+          cursor.foldResponses({}, 128)(
+            { (_, _) => sys.error("Foo"): Cursor.State[Unit] },
+            Cursor.FailOnError[Unit](onError)).recover({ case _ => count }).
+            aka("folding") must beEqualTo(1).await(timeoutMillis)
+        }
+
+        "if fails with initial value" in {
+          var count = 0
+          def onError(last: Unit, e: Throwable): Unit = { count = count + 1 }
+          val c = scol(System.identityHashCode(onError _).toString)
+          val cursor = c.find(BSONDocument.empty).cursor()
+
+          cursor.foldResponses[Unit](sys.error("Foo"), 128)(
+            (_, _) => Cursor.Cont({}), Cursor.FailOnError[Unit](onError)).
+            recover({ case _ => count }) must beEqualTo(0).await(timeoutMillis)
+        }
+
+        "if fails to send request" in {
+          var count = 0
+          def onError(last: Unit, e: Throwable): Unit = { count = count + 1 }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).cursor()
+
+          c.db.connection.close()
+          // Close connection to make the related cursor erroneous
+
+          cursor.foldResponses({}, 128)((_, _) => Cursor.Cont({}),
+            Cursor.FailOnError[Unit](onError)).recover({ case _ => count }).
+            aka("folding") must beEqualTo(1).await(timeoutMillis)
         }
       }
 
-      @inline def cursor(n: String): Cursor[Int] = {
-        implicit val reader = IdReader
-        Cursor.flatten(collection(n).map(_.find(BSONDocument()).
-          sort(BSONDocument("id" -> 1)).cursor[Int]()))
+      "when enumerating responses" >> {
+        "if fails while processing with existing documents" in {
+          var count = 0
+          val inc = Iteratee.foreach[Response] { _ =>
+            if (count == 1) sys.error("Foo")
+
+            count = count + 1
+          }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).options(
+            QueryOpts(batchSizeN = 2)).cursor()
+
+          (cursor.enumerateResponses(10, true) |>>> inc).
+            recover({ case _ => count }).
+            aka("enumerating") must beEqualTo(1).await(timeoutMillis)
+        }
+
+        "if fails while processing w/o documents" in {
+          var count = 0
+          val inc = Iteratee.foreach[Response] { _ =>
+            count = count + 1
+            sys.error("Foo")
+          }
+          val c = scol(System.identityHashCode(inc).toString)
+          val cursor = c.find(BSONDocument.empty).options(
+            QueryOpts(batchSizeN = 2)).cursor()
+
+          (cursor.enumerateResponses(10, true) |>>> inc).
+            recover({ case _ => count }) must beEqualTo(1).await(timeoutMillis)
+        }
+
+        "if fails to send request" in {
+          var count = 0
+          val inc = Iteratee.foreach[Response] { _ => count = count + 1 }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).cursor()
+
+          c.db.connection.close()
+          // Close connection to make the related cursor erroneous
+
+          (cursor.enumerateResponses(10, true) |>>> inc).
+            recover({ case _ => count }) must beEqualTo(0).await(timeoutMillis)
+        }
       }
 
-      "successfully using cursor" in {
-        (cursor("senum1").enumerate(10) |>>> toList).
-          aka("enumerated") must beEqualTo(expectedList).await(timeoutMillis)
+      "when folding bulks" >> {
+        "if fails while processing with existing documents" in {
+          var count = 0
+          def onError(last: Unit, e: Throwable): Unit = { count = count + 1 }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).options(
+            QueryOpts(batchSizeN = 64)).cursor()
+
+          cursor.foldBulks({}, 128)(
+            { (_, _) => sys.error("Foo"): Cursor.State[Unit] },
+            Cursor.FailOnError[Unit](onError)).recover({ case _ => count }).
+            aka("folding") must beEqualTo(1).await(timeoutMillis)
+        }
+
+        "if fails while processing w/o documents" in {
+          var count = 0
+          def onError(last: Unit, e: Throwable): Unit = { count = count + 1 }
+          val c = scol(System.identityHashCode(onError _).toString)
+          val cursor = c.find(BSONDocument.empty).options(
+            QueryOpts(batchSizeN = 64)).cursor()
+
+          cursor.foldBulks({}, 128)(
+            { (_, _) => sys.error("Foo"): Cursor.State[Unit] },
+            Cursor.FailOnError[Unit](onError)).recover({ case _ => count }).
+            aka("folding") must beEqualTo(1).await(timeoutMillis)
+        }
+
+        "if fails with initial value" in {
+          var count = 0
+          def onError(last: Unit, e: Throwable): Unit = { count = count + 1 }
+          val c = scol(System.identityHashCode(onError _).toString)
+          val cursor = c.find(BSONDocument.empty).options(
+            QueryOpts(batchSizeN = 64)).cursor()
+
+          cursor.foldBulks[Unit](sys.error("Foo"), 128)(
+            (_, _) => Cursor.Cont({}), Cursor.FailOnError[Unit](onError)).
+            recover({ case _ => count }) must beEqualTo(0).await(timeoutMillis)
+        }
+
+        "if fails to send request" in {
+          var count = 0
+          def onError(last: Unit, e: Throwable): Unit = { count = count + 1 }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).options(
+            QueryOpts(batchSizeN = 64)).cursor()
+
+          c.db.connection.close()
+          // Close connection to make the related cursor erroneous
+
+          cursor.foldBulks({}, 128)(
+            { (_, _) => Cursor.Cont({}) }, Cursor.FailOnError[Unit](onError)).
+            recover({ case _ => count }) must beEqualTo(1).await(timeoutMillis)
+        }
       }
+
+      "when enumerating bulks" >> {
+        "if fails while processing with existing documents" in {
+          var count = 0
+          val inc = Iteratee.foreach[Iterator[BSONDocument]] { _ =>
+            if (count == 1) sys.error("Foo")
+
+            count = count + 1
+          }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).options(
+            QueryOpts(batchSizeN = 2)).cursor()
+
+          (cursor.enumerateBulks(10, true) |>>> inc).
+            recover({ case _ => count }).
+            aka("enumerating") must beEqualTo(1).await(timeoutMillis)
+        }
+
+        "if fails while processing w/o documents" in {
+          var count = 0
+          val inc = Iteratee.foreach[Iterator[BSONDocument]] { _ =>
+            count = count + 1
+            sys.error("Foo")
+          }
+          val c = scol(System.identityHashCode(inc).toString)
+          val cursor = c.find(BSONDocument.empty).options(
+            QueryOpts(batchSizeN = 2)).cursor()
+
+          (cursor.enumerateBulks(10, true) |>>> inc).
+            recover({ case _ => count }) must beEqualTo(1).await(timeoutMillis)
+        }
+
+        "if fails to send request" in {
+          var count = 0
+          val inc = Iteratee.foreach[Iterator[BSONDocument]] { _ =>
+            count = count + 1
+          }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).cursor()
+
+          c.db.connection.close()
+          // Close connection to make the related cursor erroneous
+
+          (cursor.enumerateBulks(10, true) |>>> inc).
+            recover({ case _ => count }) must beEqualTo(0).await(timeoutMillis)
+        }
+      }
+
+      "when folding documents" >> {
+        "if fails while processing with existing documents" in {
+          var count = 0
+          def onError(last: Unit, e: Throwable): Unit = { count = count + 1 }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).cursor()
+
+          cursor.foldWhile({}, 128)(
+            { (_, _) => sys.error("Foo"): Cursor.State[Unit] },
+            Cursor.FailOnError[Unit](onError)).recover({ case _ => count }).
+            aka("folding") must beEqualTo(1).await(timeoutMillis)
+        }
+
+        "if fails with initial value" in {
+          var count = 0
+          def onError(last: Unit, e: Throwable): Unit = { count = count + 1 }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).cursor()
+
+          cursor.foldWhile[Unit](sys.error("Foo"), 128)(
+            (_, _) => Cursor.Cont({}), Cursor.FailOnError[Unit](onError)).
+            recover({ case _ => count }) must beEqualTo(0).await(timeoutMillis)
+        }
+
+        "if fails to send request" in {
+          var count = 0
+          def onError(last: Unit, e: Throwable): Unit = { count = count + 1 }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).cursor()
+
+          c.db.connection.close()
+          // Close connection to make the related cursor erroneous
+
+          cursor.foldWhile({}, 128)((_, _) => Cursor.Cont({}),
+            Cursor.FailOnError[Unit](onError)).recover({ case _ => count }).
+            aka("folding") must beEqualTo(1).await(timeoutMillis)
+        }
+      }
+
+      "when enumerating documents" >> {
+        "if fails while processing with existing documents" in {
+          var count = 0
+          val inc = Iteratee.foreach[BSONDocument] { _ =>
+            if (count == 5) sys.error("Foo")
+
+            count = count + 1
+          }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).cursor()
+
+          (cursor.enumerate(10, true) |>>> inc).recover({ case _ => count }).
+            aka("enumerating") must beEqualTo(5).await(timeoutMillis)
+        }
+
+        "if fails to send request" in {
+          var count = 0
+          val inc = Iteratee.foreach[BSONDocument] { _ => count = count + 1 }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).cursor()
+
+          c.db.connection.close()
+          // Close connection to make the related cursor erroneous
+
+          (cursor.enumerate(10, true) |>>> inc).recover({ case _ => count }).
+            aka("enumerating") must beEqualTo(0).await(timeoutMillis)
+        }
+      }
+
+      "Driver instance must be closed" in {
+        drv.close() must not(throwA[Exception])
+      }
+    }
+
+    "continue on error" >> {
+      val drv = new MongoDriver
+      def con = drv.connection(List("localhost:27017"), DefaultOptions)
+      def scol(n: String = coll.name) = { val d = con(db.name); d(n) }
+
+      "when folding responses" >> {
+        "if fails while processing with existing documents" in {
+          var count = 0
+          def onError(last: Unit, e: Throwable): Unit = { count = count + 1 }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).cursor()
+
+          cursor.foldResponses({}, 128)(
+            { (_, _) => sys.error("Foo"): Cursor.State[Unit] },
+            Cursor.ContOnError[Unit](onError)).map(_ => count).
+            aka("folding") must beEqualTo(128).await(timeoutMillis)
+        }
+
+        "if fails while processing w/o documents" in {
+          var count = 0
+          def onError(last: Unit, e: Throwable): Unit = { count = count + 1 }
+          val c = scol(System.identityHashCode(onError _).toString)
+          val cursor = c.find(BSONDocument.empty).cursor()
+
+          cursor.foldResponses({}, 64)(
+            { (_, _) => sys.error("Foo"): Cursor.State[Unit] },
+            Cursor.ContOnError[Unit](onError)).map(_ => count).
+            aka("folding") must beEqualTo(64).await(timeoutMillis)
+        }
+
+        "if fails with initial value" in {
+          var count = 0
+          def onError(last: Unit, e: Throwable): Unit = { count = count + 1 }
+          val c = scol(System.identityHashCode(onError _).toString)
+          val cursor = c.find(BSONDocument.empty).cursor()
+
+          cursor.foldResponses[Unit](sys.error("Foo"), 128)(
+            (_, _) => Cursor.Cont({}), Cursor.ContOnError[Unit](onError)).
+            recover({ case _ => count }) must beEqualTo(0).await(timeoutMillis)
+        }
+
+        "if fails to send request" in {
+          var count = 0
+          def onError(last: Unit, e: Throwable): Unit = { count = count + 1 }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).cursor()
+
+          c.db.connection.close()
+          // Close connection to make the related cursor erroneous
+
+          cursor.foldResponses({}, 128)((_, _) => Cursor.Cont({}),
+            Cursor.ContOnError[Unit](onError)).map(_ => count).
+            aka("folding") must beEqualTo(1).await(timeoutMillis)
+        }
+      }
+
+      "when enumerating responses" >> {
+        "if fails while processing with existing documents" in {
+          var count = 0
+          var i = 0
+          val inc = Iteratee.foreach[Response] { _ =>
+            i = i + 1
+            if (i % 2 == 0) sys.error("Foo")
+            count = count + 1
+          }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).options(QueryOpts(
+            batchSizeN = 4)).cursor()
+
+          (cursor.enumerateResponses(128, false) |>>> inc).map(_ => count).
+            aka("enumerating") must beEqualTo(16).await(timeoutMillis)
+        }
+
+        "if fails while processing w/o documents" in {
+          var count = 0
+          val inc = Iteratee.foreach[Response] { _ =>
+            count = count + 1
+            sys.error("Foo")
+          }
+          val c = scol(System.identityHashCode(inc).toString)
+          val cursor = c.find(BSONDocument.empty).
+            options(QueryOpts(batchSizeN = 2)).cursor()
+
+          (cursor.enumerateResponses(64, false) |>>> inc).map(_ => count).
+            aka("enumerating") must beEqualTo(1).await(timeoutMillis)
+        }
+
+        "if fails to send request" in {
+          var count = 0
+          val inc = Iteratee.foreach[Response] { _ => count = count + 1 }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).cursor()
+
+          c.db.connection.close()
+          // Close connection to make the related cursor erroneous
+
+          (cursor.enumerateResponses(128, false) |>>> inc).
+            recover({ case _ => count }) must beEqualTo(0).await(timeoutMillis)
+        }
+      }
+
+      "when folding bulks" >> {
+        "if fails while processing with existing documents" in {
+          var count = 0
+          def onError(last: Unit, e: Throwable): Unit = { count = count + 1 }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).options(
+            QueryOpts(batchSizeN = 64)).cursor()
+
+          cursor.foldBulks({}, 128)(
+            { (_, _) => sys.error("Foo"): Cursor.State[Unit] },
+            Cursor.ContOnError[Unit](onError)).map(_ => count).
+            aka("folding") must beEqualTo(128).await(timeoutMillis)
+        }
+
+        "if fails while processing w/o documents" in {
+          var count = 0
+          def onError(last: Unit, e: Throwable): Unit = { count = count + 1 }
+          val c = scol(System.identityHashCode(onError _).toString)
+          val cursor = c.find(BSONDocument.empty).options(
+            QueryOpts(batchSizeN = 64)).cursor()
+
+          cursor.foldBulks({}, 64)(
+            { (_, _) => sys.error("Foo"): Cursor.State[Unit] },
+            Cursor.ContOnError[Unit](onError)).map(_ => count).
+            aka("folding") must beEqualTo(64).await(timeoutMillis)
+        }
+
+        "if fails with initial value" in {
+          var count = 0
+          def onError(last: Unit, e: Throwable): Unit = { count = count + 1 }
+          val c = scol(System.identityHashCode(onError _).toString)
+          val cursor = c.find(BSONDocument.empty).options(
+            QueryOpts(batchSizeN = 64)).cursor()
+
+          cursor.foldBulks[Unit](sys.error("Foo"), 128)(
+            (_, _) => Cursor.Cont({}), Cursor.ContOnError[Unit](onError)).
+            recover({ case _ => count }) must beEqualTo(0).await(timeoutMillis)
+        }
+
+        "if fails to send request" in {
+          var count = 0
+          def onError(last: Unit, e: Throwable): Unit = { count = count + 1 }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).options(
+            QueryOpts(batchSizeN = 64)).cursor()
+
+          c.db.connection.close()
+          // Close connection to make the related cursor erroneous
+
+          cursor.foldBulks({}, 128)(
+            { (_, _) => Cursor.Cont({}) }, Cursor.ContOnError[Unit](onError)).
+            map(_ => count) must beEqualTo(1).await(timeoutMillis)
+        }
+      }
+
+      "when enumerating bulks" >> {
+        "if fails while processing with existing documents" in {
+          var count = 0
+          var i = 0
+          val inc = Iteratee.foreach[Iterator[BSONDocument]] { _ =>
+            i = i + 1
+            if (i % 2 == 0) sys.error("Foo")
+            count = count + 1
+          }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).options(QueryOpts(
+            batchSizeN = 4)).cursor()
+
+          (cursor.enumerateBulks(128, false) |>>> inc).map(_ => count).
+            aka("enumerating") must beEqualTo(16).await(timeoutMillis)
+        }
+
+        "if fails while processing w/o documents" in {
+          var count = 0
+          val inc = Iteratee.foreach[Iterator[BSONDocument]] { _ =>
+            count = count + 1
+            sys.error("Foo")
+          }
+          val c = scol(System.identityHashCode(inc).toString)
+          val cursor = c.find(BSONDocument.empty).
+            options(QueryOpts(batchSizeN = 2)).cursor()
+
+          (cursor.enumerateBulks(64, false) |>>> inc).map(_ => count).
+            aka("enumerating") must beEqualTo(1).await(timeoutMillis)
+        }
+
+        "if fails to send request" in {
+          var count = 0
+          val inc = Iteratee.foreach[Iterator[BSONDocument]] {
+            _ => count = count + 1
+          }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).cursor()
+
+          c.db.connection.close()
+          // Close connection to make the related cursor erroneous
+
+          (cursor.enumerateBulks(128, false) |>>> inc).
+            recover({ case _ => count }) must beEqualTo(0).await(timeoutMillis)
+        }
+      }
+
+      "when folding documents" >> {
+        "if fails while processing with existing documents" in {
+          var count = 0
+          def onError(last: Unit, e: Throwable): Unit = { count = count + 1 }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).cursor()
+
+          cursor.foldWhile({}, 128)(
+            { (_, _) => sys.error("Foo"): Cursor.State[Unit] },
+            Cursor.ContOnError[Unit](onError)).map(_ => count).
+            aka("folding") must beEqualTo(128).await(timeoutMillis)
+        }
+
+        "if fails with initial value" in {
+          var count = 0
+          def onError(last: Unit, e: Throwable): Unit = { count = count + 1 }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).cursor()
+
+          cursor.foldWhile[Unit](sys.error("Foo"), 128)(
+            (_, _) => Cursor.Cont({}), Cursor.ContOnError[Unit](onError)).
+            recover({ case _ => count }) must beEqualTo(0).await(timeoutMillis)
+        }
+
+        "if fails to send request" in {
+          var count = 0
+          def onError(last: Unit, e: Throwable): Unit = { count = count + 1 }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).cursor()
+
+          c.db.connection.close()
+          // Close connection to make the related cursor erroneous
+
+          cursor.foldWhile({}, 64)((_, _) => Cursor.Cont({}),
+            Cursor.ContOnError[Unit](onError)).map(_ => count).
+            aka("folding") must beEqualTo(1).await(timeoutMillis)
+        }
+      }
+
+      "when enumerating documents" >> {
+        "if fails while processing with existing documents" in {
+          var count = 0
+          var i = 0
+          val inc = Iteratee.foreach[BSONDocument] { _ =>
+            i = i + 1
+            if (i % 2 == 0) sys.error("Foo")
+            count = count + 1
+          }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).options(QueryOpts(
+            batchSizeN = 4)).cursor()
+
+          (cursor.enumerate(128, false) |>>> inc).map(_ => count).
+            aka("enumerating") must beEqualTo(32).await(timeoutMillis)
+        }
+
+        "if fails while processing w/o documents" in {
+          var count = 0
+          val inc = Iteratee.foreach[BSONDocument] { _ =>
+            count = count + 1
+            sys.error("Foo")
+          }
+          val c = scol(System.identityHashCode(inc).toString)
+          val cursor = c.find(BSONDocument.empty).
+            options(QueryOpts(batchSizeN = 2)).cursor()
+
+          (cursor.enumerate(64, false) |>>> inc).map(_ => count).
+            aka("enumerating") must beEqualTo(0).await(timeoutMillis)
+        }
+
+        "if fails to send request" in {
+          var count = 0
+          val inc = Iteratee.foreach[BSONDocument] {
+            _ => count = count + 1
+          }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).cursor()
+
+          c.db.connection.close()
+          // Close connection to make the related cursor erroneous
+
+          (cursor.enumerate(128, false) |>>> inc).
+            recover({ case _ => count }) must beEqualTo(0).await(timeoutMillis)
+        }
+      }
+
+      "Driver instance must be closed" in {
+        drv.close() must not(throwA[Exception])
+      }
+    }
+  }
+
+  "BSON cursor" should {
+    object IdReader extends BSONDocumentReader[Int] {
+      def read(doc: BSONDocument): Int = doc.getAs[Int]("id").get
     }
 
     "read from capped collection" >> {
@@ -127,25 +721,31 @@ object CursorSpec extends Specification {
 
       @inline def tailable(n: String, database: DB = db) = {
         implicit val reader = IdReader
-        collection(n, database).find(BSONDocument()).options(
+        collection(n, database).find(BSONDocument.empty).options(
           QueryOpts().tailable).cursor[Int]()
       }
 
-      "successfully using tailable enumerator with maxDocs" in {
-        (tailable("tenum1").enumerate(10) |>>> toList).
-          aka("enumerated") must beEqualTo(expectedList).await(timeoutMillis)
-      }
+      "using tailable" >> {
+        "to fold responses" in {
+          implicit val reader = IdReader
+          tailable("foldr0").foldResponses(List.empty[Int], 6) { (s, resp) =>
+            val bulk = Response.parse(resp).flatMap(_.asOpt[Int].toList)
 
-      "with timeout using tailable enumerator w/o maxDocs" in {
-        Await.result(tailable("tenum2").enumerate() |>>> toList, timeout).
-          aka("enumerated") must throwA[Exception]
+            Cursor.Cont(s ++ bulk)
+          } must beEqualTo(List(0, 1, 2, 3, 4, 5)).await(2500)
+        }
+
+        "to fold bulks" in {
+          tailable("foldw0").foldBulks(List.empty[Int], 6)(
+            (s, bulk) => Cursor.Cont(s ++ bulk)) must beEqualTo(List(
+              0, 1, 2, 3, 4, 5)).await(2500)
+        }
       }
 
       "using tailable foldWhile" >> {
         "successfully" in {
           tailable("foldw1").foldWhile(List.empty[Int], 5)(
-            (s, i) => Cursor.Cont(i :: s),
-            (_, e) => Cursor.Fail(e)) must beEqualTo(List(
+            (s, i) => Cursor.Cont(i :: s)) must beEqualTo(List(
               4, 3, 2, 1, 0)).await(2500)
         }
 

--- a/driver/src/test/scala/commands/FindAndModifySpec.scala
+++ b/driver/src/test/scala/commands/FindAndModifySpec.scala
@@ -1,5 +1,4 @@
 import org.specs2.mutable._
-import play.api.libs.iteratee.Enumerator
 import scala.util.{ Try, Failure }
 import scala.util.control.NonFatal
 

--- a/iteratees/src/main/scala/cursor.scala
+++ b/iteratees/src/main/scala/cursor.scala
@@ -1,0 +1,96 @@
+package reactivemongo.play.iteratees
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+import play.api.libs.iteratee.{ Concurrent, Enumerator, Iteratee }
+
+import reactivemongo.core.protocol.Response
+import reactivemongo.api.{
+  Cursor,
+  CursorProducer,
+  FlattenedCursor,
+  WrappedCursor
+}, Cursor.{ ErrorHandler, FailOnError }
+
+sealed trait PlayIterateesCursor[T] extends Cursor[T] {
+  /**
+   * Produces an Enumerator of documents.
+   *
+   * @param maxDocs Enumerate up to `maxDocs` documents.
+   * @param err The binary operator to be applied when failing to get the next response. Exception or [[Fail]] raised within the `suc` function cannot be recovered by this error handler. Only the errors when reading the inputs from the DB will be handle: if then an `Iteratee` is failing to process, the error is out of this mechanism scope.
+   *
+   * @return an Enumerator of documents.
+   */
+  def enumerator(maxDocs: Int = Int.MaxValue, err: ErrorHandler[Unit] = FailOnError[Unit]())(implicit ctx: ExecutionContext): Enumerator[T]
+
+  /**
+   * Produces an Enumerator of Iterator of documents.
+   *
+   * @param maxDocs Enumerate up to `maxDocs` documents.
+   * @param err The binary operator to be applied when failing to get the next response. Exception or [[Fail]] raised within the `suc` function cannot be recovered by this error handler. Only the errors when reading the inputs from the DB will be handle: if then an `Iteratee` is failing to process, the error is out of this mechanism scope.
+   *
+   * @return an Enumerator of Iterators of documents.
+   */
+  def bulkEnumerator(maxDocs: Int = Int.MaxValue, err: ErrorHandler[Unit] = FailOnError[Unit]())(implicit ctx: ExecutionContext): Enumerator[Iterator[T]]
+
+  /**
+   * Produces an Enumerator of responses from the database.
+   *
+   * @param maxDocs Enumerate up to `maxDocs` documents.
+   * @param err The binary operator to be applied when failing to get the next response. Exception or [[Fail]] raised within the `suc` function cannot be recovered by this error handler. Only the errors when reading the inputs from the DB will be handle: if then an `Iteratee` is failing to process, the error is out of this mechanism scope.
+   *
+   * @return an Enumerator of Responses.
+   */
+  def responseEnumerator(maxDocs: Int = Int.MaxValue, err: ErrorHandler[Unit] = FailOnError[Unit]())(implicit ctx: ExecutionContext): Enumerator[Response]
+
+}
+
+class PlayIterateesCursorImpl[T](val wrappee: Cursor[T])
+    extends PlayIterateesCursor[T] with WrappedCursor[T] {
+  import Cursor.{ Cont, Fail, State }
+
+  private def errorHandler[T](chan: Concurrent.Channel[T], err: ErrorHandler[Unit]): ErrorHandler[Unit] = {
+    val after: State[Unit] => State[Unit] = {
+      case f @ Fail(e) => {
+        chan.end(e)
+        f
+      }
+
+      case st => st
+    }
+
+    (v, e) => after(err(v, e))
+  }
+
+  override def enumerator(maxDocs: Int = Int.MaxValue, err: ErrorHandler[Unit] = FailOnError[Unit]())(implicit ctx: ExecutionContext): Enumerator[T] =
+    Concurrent.unicast[T] { chan =>
+      wrappee.foldWhile({}, maxDocs)(
+        (_, res) => Cont(chan push res), errorHandler(chan, err)).
+        onComplete { case _ => chan.eofAndEnd() }
+    }
+
+  override def bulkEnumerator(maxDocs: Int = Int.MaxValue, err: ErrorHandler[Unit] = FailOnError[Unit]())(implicit ctx: ExecutionContext): Enumerator[Iterator[T]] = Concurrent.unicast[Iterator[T]] { chan =>
+    wrappee.foldBulks({}, maxDocs)(
+      (_, bulk) => Cont(chan push bulk), errorHandler(chan, err)).
+      onComplete { case _ => chan.eofAndEnd() }
+  }
+
+  override def responseEnumerator(maxDocs: Int = Int.MaxValue, err: ErrorHandler[Unit] = FailOnError[Unit]())(implicit ctx: ExecutionContext): Enumerator[Response] = Concurrent.unicast[Response] { chan =>
+    wrappee.foldResponses({}, maxDocs)(
+      (_, resp) => Cont(chan push resp), errorHandler(chan, err)).
+      onComplete { case _ => chan.eofAndEnd() }
+  }
+
+}
+
+class PlayIterateesFlattenedCursor[T](
+  val cursor: Future[PlayIterateesCursor[T]])
+    extends FlattenedCursor[T](cursor) with PlayIterateesCursor[T] {
+
+  override def enumerator(maxDocs: Int = Int.MaxValue, err: ErrorHandler[Unit] = FailOnError[Unit]())(implicit ctx: ExecutionContext): Enumerator[T] = Enumerator.flatten(cursor.map(_.enumerator(maxDocs, err)))
+
+  override def bulkEnumerator(maxDocs: Int = Int.MaxValue, err: ErrorHandler[Unit] = FailOnError[Unit]())(implicit ctx: ExecutionContext): Enumerator[Iterator[T]] = Enumerator.flatten(cursor.map(_.bulkEnumerator(maxDocs, err)))
+
+  override def responseEnumerator(maxDocs: Int = Int.MaxValue, err: ErrorHandler[Unit] = FailOnError[Unit]())(implicit ctx: ExecutionContext): Enumerator[Response] = Enumerator.flatten(cursor.map(_.responseEnumerator(maxDocs, err)))
+
+}

--- a/iteratees/src/main/scala/package.scala
+++ b/iteratees/src/main/scala/package.scala
@@ -1,0 +1,23 @@
+package reactivemongo.play
+
+import scala.concurrent.Future
+import reactivemongo.api.{ Cursor, CursorProducer }
+
+package object iteratees {
+  /** Provides Play Iteratees instances for CursorProducer typeclass. */
+  implicit def cursorProducer[T] = new CursorProducer[T] {
+    type ProducedCursor = PlayIterateesCursor[T]
+
+    // Returns a cursor with Play Iteratees operations.
+    def produce(base: Cursor[T]): PlayIterateesCursor[T] =
+      new PlayIterateesCursorImpl[T](base)
+
+  }
+
+  /** Provides flattener for Play Iteratees cursor. */
+  implicit object cursorFlattener
+      extends reactivemongo.api.CursorFlattener[PlayIterateesCursor] {
+
+    def flatten[T](future: Future[PlayIterateesCursor[T]]): PlayIterateesCursor[T] = new PlayIterateesFlattenedCursor(future)
+  }
+}

--- a/iteratees/src/test/scala/CursorSpec.scala
+++ b/iteratees/src/test/scala/CursorSpec.scala
@@ -1,0 +1,541 @@
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration.DurationInt
+
+import play.api.libs.iteratee.Iteratee
+
+import reactivemongo.bson.{
+  BSONDocument,
+  BSONDocumentReader,
+  BSONDocumentWriter,
+  BSONInteger,
+  BSONString
+}
+import reactivemongo.api.{
+  Cursor,
+  DB,
+  QueryOpts,
+  MongoDriver
+}, Cursor.{ ContOnError, FailOnError }
+import reactivemongo.core.protocol.Response
+import reactivemongo.play.iteratees.PlayIterateesCursor
+
+object CursorSpec extends org.specs2.mutable.Specification {
+  "Cursor" title
+
+  sequential
+
+  import Common._
+  import reactivemongo.play.iteratees.cursorProducer
+
+  "BSON collection" should {
+    "be provided the fixtures" >> {
+      val fixtures = List(
+        Person("Jack", 25),
+        Person("James", 16),
+        Person("John", 34),
+        Person("Jane", 24),
+        Person("Joline", 34))
+
+      "with insert" in {
+        implicit val writer = PersonWriter
+
+        Future.sequence(fixtures.map(personColl.insert(_).map(_.ok))).
+          aka("fixtures") must beEqualTo(List(true, true, true, true, true)).
+          await(timeoutMillis)
+      }
+    }
+
+    "read empty cursor" >> {
+      @inline def cursor: PlayIterateesCursor[BSONDocument] =
+        personColl.find(BSONDocument("plop" -> "plop")).cursor[BSONDocument]()
+
+      "with success using enumerate" in {
+        val cur = cursor
+        val enumerator = cur.enumerator(10)
+
+        (enumerator |>>> Iteratee.fold(0) { (r, doc) => r + 1 }).
+          aka("read") must beEqualTo(0).await(timeoutMillis)
+      }
+    }
+
+    "read documents until error" in {
+      implicit val reader = new SometimesBuggyPersonReader
+      val enumerator = personColl.find(BSONDocument()).
+        cursor[Person]().enumerator()
+
+      var i = 0
+      (enumerator |>>> Iteratee.foreach { doc =>
+        i += 1
+        //println(s"\tgot doc: $doc")
+      } map (_ => -1)).
+        recover({ case e => i }) must beEqualTo(3).await(timeoutMillis)
+    }
+
+    "read documents skipping errors" in {
+      implicit val reader = new SometimesBuggyPersonReader
+      val enumerator = personColl.find(BSONDocument()).
+        cursor[Person]().enumerator(err = ContOnError[Unit]())
+
+      var i = 0
+      (enumerator |>>> Iteratee.foreach { doc =>
+        i += 1
+        //println(s"\t(skipping [$i]) got doc: $doc")
+      }).map(_ => i) must beEqualTo(4).await(timeoutMillis)
+    }
+
+    "insert 16,517 records" in {
+      val futs = for (i <- 0 until 16517)
+        yield coll2.insert(BSONDocument(
+        "i" -> BSONInteger(i), "record" -> BSONString("record" + i)))
+
+      Future.sequence(futs).map(_ => {}) must beEqualTo({}).
+        await(20000 /* 20s */ )
+    }
+
+    "enumerate" >> {
+      "all the 16,517 documents" in {
+        var i = 0
+        coll2.find(BSONDocument.empty).cursor[BSONDocument]().enumerator() |>>> (
+          Iteratee.foreach { e: BSONDocument =>
+            //println(s"doc $i => $e")
+            i += 1
+          }).map(_ => i) must beEqualTo(16517).await(21000 /*21s*/ )
+      }
+
+      "only 1024 documents" in {
+        var i = 0
+        coll2.find(BSONDocument.empty).cursor[BSONDocument]().
+          enumerator(1024) |>>> (Iteratee.foreach { e: BSONDocument =>
+            //println(s"doc $i => $e")
+            i += 1
+          }).map(_ => i) must beEqualTo(1024).await(timeoutMillis)
+      }
+    }
+
+    "enumerate bulks" >> {
+      "for all the documents" in {
+        var i = 0
+        coll2.find(BSONDocument.empty).cursor[BSONDocument]().
+          bulkEnumerator() |>>> (
+            Iteratee.foreach { it: Iterator[BSONDocument] =>
+              //println(s"doc $i => $e")
+              i += it.size
+            }).map(_ => i) must beEqualTo(16517).await(21000 /*21s*/ )
+      }
+
+      "for only 1024 documents" in {
+        var i = 0
+        coll2.find(BSONDocument.empty).cursor[BSONDocument]().
+          bulkEnumerator(1024) |>>> (
+            Iteratee.foreach { it: Iterator[BSONDocument] =>
+              //println(s"doc $i => $e")
+              i += it.size
+            }).map(_ => i) must beEqualTo(1024).await(timeoutMillis)
+      }
+    }
+
+    "enumerate responses" >> {
+      "for all the 16,517 documents" in {
+        var i = 0
+        coll2.find(BSONDocument.empty).cursor[BSONDocument]().
+          responseEnumerator() |>>> (Iteratee.foreach { r: Response =>
+            //println(s"doc $i => $e")
+            i += r.reply.numberReturned
+          }).map(_ => i) must beEqualTo(16517).await(21000 /*21s*/ )
+      }
+
+      "for only 1024 documents" in {
+        var i = 0
+        coll2.find(BSONDocument.empty).cursor[BSONDocument]().
+          responseEnumerator(1024) |>>> (Iteratee.foreach { r: Response =>
+            //println(s"doc $i => $e")
+            i += r.reply.numberReturned
+          }).map(_ => i) must beEqualTo(1024).await(timeoutMillis)
+      }
+    }
+
+    "stop on error" >> {
+      val drv = new MongoDriver
+      def con = drv.connection(List("localhost:27017"), DefaultOptions)
+      def scol(n: String = coll2.name) = Await.result(for {
+        d <- con.database(db.name)
+        c <- d.coll(n)
+      } yield c, timeout)
+
+      "when enumerating responses" >> {
+        "if fails while processing with existing documents (#1)" in {
+          var count = 0
+          val inc = Iteratee.foreach[Response] { _ =>
+            if (count == 1) sys.error("Foo")
+
+            count = count + 1
+          }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).options(
+            QueryOpts(batchSizeN = 2)).cursor()
+
+          (cursor.responseEnumerator(10, FailOnError[Unit]()) |>>> inc).
+            recover({ case _ => count }).
+            aka("enumerating") must beEqualTo(1).await(timeoutMillis)
+        }
+
+        "if fails while processing with existing documents (#2)" in {
+          // As the error is on the consuming side (Iteratee)
+          var count = 0
+          var i = 0
+          val inc = Iteratee.foreach[Response] { _ =>
+            i = i + 1
+            if (i % 2 == 0) sys.error("Foo")
+            count = count + 1
+          }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).options(QueryOpts(
+            batchSizeN = 4)).cursor()
+
+          (cursor.responseEnumerator(128, ContOnError[Unit]()) |>>> inc).
+            recover({ case _ => count }) must beEqualTo(1).await(timeoutMillis)
+        }
+
+        "if fails while processing w/o documents (#1)" in {
+          var count = 0
+          val inc = Iteratee.foreach[Response] { _ =>
+            count = count + 1
+            sys.error("Foo")
+          }
+          val c = scol(System.identityHashCode(inc).toString)
+          val cursor = c.find(BSONDocument.empty).options(
+            QueryOpts(batchSizeN = 2)).cursor()
+
+          (cursor.responseEnumerator(10, FailOnError[Unit]()) |>>> inc).
+            recover({ case _ => count }) must beEqualTo(1).await(timeoutMillis)
+        }
+
+        "if fails while processing w/o documents (#2)" in {
+          // As the error is on the consuming side (Iteratee)          
+          var count = 0
+          val inc = Iteratee.foreach[Response] { _ =>
+            count = count + 1
+            sys.error("Foo")
+          }
+          val c = scol(System.identityHashCode(inc).toString)
+          val cursor = c.find(BSONDocument.empty).
+            options(QueryOpts(batchSizeN = 2)).cursor()
+
+          (cursor.responseEnumerator(64, ContOnError[Unit]()) |>>> inc).
+            recover({ case _ => count }) must beEqualTo(1).await(timeoutMillis)
+        }
+
+        "if fails to send request" in {
+          var count = 0
+          val inc = Iteratee.foreach[Response] { _ => count = count + 1 }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).cursor()
+
+          c.db.connection.close()
+          // Close connection to make the related cursor erroneous
+
+          (cursor.responseEnumerator(10, FailOnError[Unit]()) |>>> inc).
+            recover({ case _ => count }) must beEqualTo(0).await(timeoutMillis)
+        }
+      }
+
+      "when enumerating bulks" >> {
+        "if fails while processing with existing documents (#1)" in {
+          var count = 0
+          val inc = Iteratee.foreach[Iterator[BSONDocument]] { _ =>
+            if (count == 1) sys.error("Foo")
+
+            count = count + 1
+          }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).options(
+            QueryOpts(batchSizeN = 2)).cursor()
+
+          (cursor.bulkEnumerator(10, FailOnError[Unit]()) |>>> inc).
+            recover({ case _ => count }).
+            aka("enumerating") must beEqualTo(1).await(timeoutMillis)
+        }
+
+        "if fails while processing with existing documents (#2)" in {
+          var count = 0
+          var i = 0
+          val inc = Iteratee.foreach[Iterator[BSONDocument]] { _ =>
+            i = i + 1
+            if (i % 2 == 0) sys.error("Foo")
+            count = count + 1
+          }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).options(QueryOpts(
+            batchSizeN = 4)).cursor()
+
+          (cursor.bulkEnumerator(128, ContOnError[Unit]()) |>>> inc).
+            recover({ case _ => count }) must beEqualTo(1).await(timeoutMillis)
+        }
+
+        "if fails while processing w/o documents (#1)" in {
+          var count = 0
+          val inc = Iteratee.foreach[Iterator[BSONDocument]] { _ =>
+            count = count + 1
+            sys.error("Foo")
+          }
+          val c = scol(System.identityHashCode(inc).toString)
+          val cursor = c.find(BSONDocument.empty).options(
+            QueryOpts(batchSizeN = 2)).cursor()
+
+          (cursor.bulkEnumerator(10, FailOnError[Unit]()) |>>> inc).
+            recover({ case _ => count }) must beEqualTo(1).await(timeoutMillis)
+        }
+
+        "if fails while processing w/o documents (#2)" in {
+          var count = 0
+          val inc = Iteratee.foreach[Iterator[BSONDocument]] { _ =>
+            count = count + 1
+            sys.error("Foo")
+          }
+          val c = scol(System.identityHashCode(inc).toString)
+          val cursor = c.find(BSONDocument.empty).
+            options(QueryOpts(batchSizeN = 2)).cursor()
+
+          (cursor.bulkEnumerator(64, ContOnError[Unit]()) |>>> inc).
+            recover({ case _ => count }) must beEqualTo(1).await(timeoutMillis)
+        }
+
+        "if fails to send request" in {
+          var count = 0
+          val inc = Iteratee.foreach[Iterator[BSONDocument]] { _ =>
+            count = count + 1
+          }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).cursor()
+
+          c.db.connection.close()
+          // Close connection to make the related cursor erroneous
+
+          (cursor.bulkEnumerator(10, FailOnError[Unit]()) |>>> inc).
+            recover({ case _ => count }) must beEqualTo(0).await(timeoutMillis)
+        }
+      }
+
+      "when enumerating documents" >> {
+        "if fails while processing with existing documents" in {
+          var count = 0
+          val inc = Iteratee.foreach[BSONDocument] { _ =>
+            if (count == 5) sys.error("Foo")
+
+            count = count + 1
+          }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).cursor()
+
+          (cursor.enumerator(10, FailOnError[Unit]()) |>>> inc).
+            recover({ case _ => count }) must beEqualTo(5).await(timeoutMillis)
+        }
+
+        "if fails to send request" in {
+          var count = 0
+          val inc = Iteratee.foreach[BSONDocument] { _ => count = count + 1 }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).cursor()
+
+          c.db.connection.close()
+          // Close connection to make the related cursor erroneous
+
+          (cursor.enumerator(10, FailOnError[Unit]()) |>>> inc).
+            recover({ case _ => count }) must beEqualTo(0).await(timeoutMillis)
+        }
+      }
+
+      "Driver instance must be closed" in {
+        drv.close() must not(throwA[Exception])
+      }
+    }
+
+    "continue on error" >> {
+      val drv = new MongoDriver
+      def con = drv.connection(List("localhost:27017"), DefaultOptions)
+      def scol(n: String = coll2.name) = { val d = con(db.name); d(n) }
+
+      "when enumerating responses" >> {
+        "if fails to send request" in {
+          var count = 0
+          val inc = Iteratee.foreach[Response] { _ => count = count + 1 }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).cursor()
+
+          c.db.connection.close()
+          // Close connection to make the related cursor erroneous
+
+          (cursor.responseEnumerator(128, ContOnError[Unit]()) |>>> inc).
+            map(_ => count) must beEqualTo(0).await(timeoutMillis)
+        }
+      }
+
+      "when enumerating bulks" >> {
+        "if fails to send request" in {
+          var count = 0
+          val inc = Iteratee.foreach[Iterator[BSONDocument]] {
+            _ => count = count + 1
+          }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).cursor()
+
+          c.db.connection.close()
+          // Close connection to make the related cursor erroneous
+
+          (cursor.bulkEnumerator(128, ContOnError[Unit]()) |>>> inc).
+            map(_ => count) must beEqualTo(0).await(timeoutMillis)
+        }
+      }
+
+      "when enumerating documents" >> {
+        "if fails while processing with existing documents" in {
+          var count = 0
+          var i = 0
+          val inc = Iteratee.foreach[BSONDocument] { _ =>
+            i = i + 1
+            if (i % 2 == 0) sys.error("Foo")
+            count = count + 1
+          }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).options(QueryOpts(
+            batchSizeN = 4)).cursor()
+
+          (cursor.enumerator(128, ContOnError[Unit]()) |>>> inc).
+            recover({ case _ => count }) must beEqualTo(1).await(timeoutMillis)
+        }
+
+        "if fails while processing w/o documents" in {
+          var count = 0
+          val inc = Iteratee.foreach[BSONDocument] { _ =>
+            count = count + 1
+            sys.error("Foo")
+          }
+          val c = scol(System.identityHashCode(inc).toString)
+          val cursor = c.find(BSONDocument.empty).
+            options(QueryOpts(batchSizeN = 2)).cursor()
+
+          (cursor.enumerator(64, ContOnError[Unit]()) |>>> inc).map(_ => count).
+            aka("enumerating") must beEqualTo(0).await(timeoutMillis)
+        }
+
+        "if fails to send request" in {
+          var count = 0
+          val inc = Iteratee.foreach[BSONDocument] {
+            _ => count = count + 1
+          }
+          val c = scol()
+          val cursor = c.find(BSONDocument.empty).cursor()
+
+          c.db.connection.close()
+          // Close connection to make the related cursor erroneous
+
+          (cursor.enumerator(128, ContOnError[Unit]()) |>>> inc).
+            map(_ => count) must beEqualTo(0).await(timeoutMillis)
+        }
+      }
+
+      "Driver instance must be closed" in {
+        drv.close() must not(throwA[Exception])
+      }
+    }
+  }
+
+  "BSON Cursor" should {
+    object IdReader extends BSONDocumentReader[Int] {
+      def read(doc: BSONDocument): Int = doc.getAs[Int]("id").get
+    }
+
+    val expectedList = List(9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+    val toList =
+      Iteratee.fold[Int, List[Int]](List.empty[Int]) { (l, i) => i :: l }
+
+    "read from collection" >> {
+      def collection(n: String) = {
+        val col = db(s"somecollection_$n")
+
+        Future.sequence((0 until 10) map { id =>
+          col.insert(BSONDocument("id" -> id))
+        }) map { _ =>
+          println(s"-- all documents inserted in test collection $n")
+          col
+        }
+      }
+
+      @inline def cursor(n: String): PlayIterateesCursor[Int] = {
+        implicit val reader = IdReader
+        Cursor.flatten(collection(n).map(_.find(BSONDocument()).
+          sort(BSONDocument("id" -> 1)).cursor[Int]()))
+      }
+
+      "successfully using cursor enumerator" >> {
+        "per document" in {
+          (cursor("senum1").enumerator(10) |>>> toList).
+            aka("enumerated") must beEqualTo(expectedList).await(timeoutMillis)
+        }
+
+        "per bulk" in {
+          val collect = Iteratee.fold[Iterator[Int], List[Int]](
+            List.empty[Int]) { _ ++ _ }
+
+          (cursor("senum2").bulkEnumerator(10) |>>> collect).map(_.reverse).
+            aka("enumerated") must beEqualTo(expectedList).await(timeoutMillis)
+        }
+      }
+    }
+
+    "read from capped collection" >> {
+      def collection(n: String, database: DB) = {
+        val col = database(s"somecollection_captail_$n")
+
+        col.createCapped(4096, Some(10)).flatMap { _ =>
+          (0 until 10).foldLeft(Future successful {}) { (f, id) =>
+            f.flatMap(_ => col.insert(BSONDocument("id" -> id)).map(_ =>
+              Thread.sleep(200)))
+          }.map(_ =>
+            println(s"-- all documents inserted in test collection $n"))
+        }
+
+        col
+      }
+
+      @inline def tailable(n: String, database: DB = db) = {
+        implicit val reader = IdReader
+        collection(n, database).find(BSONDocument()).options(
+          QueryOpts().tailable).cursor[Int]()
+      }
+
+      "successfully using tailable enumerator with maxDocs" in {
+        (tailable("tenum1").enumerator(10) |>>> toList).
+          aka("enumerated") must beEqualTo(expectedList).await(timeoutMillis)
+      }
+
+      "with timeout using tailable enumerator w/o maxDocs" in {
+        Await.result((tailable("tenum2").enumerator() |>>> toList), timeout).
+          aka("enumerated") must throwA[java.util.concurrent.TimeoutException]
+      }
+    }
+  }
+
+  // ---
+
+  lazy val personColl = db("playiteratees_person")
+  lazy val coll2 = db(s"playiteratees_${System identityHashCode personColl}")
+
+  case class Person(name: String, age: Int)
+
+  class SometimesBuggyPersonReader extends BSONDocumentReader[Person] {
+    private var i = 0
+    def read(doc: BSONDocument): Person = {
+      i += 1
+      if (i % 4 == 0) throw CustomException("hey hey hey")
+      else Person(doc.getAs[String]("name").get, doc.getAs[Int]("age").get)
+    }
+  }
+
+  object PersonWriter extends BSONDocumentWriter[Person] {
+    def write(p: Person): BSONDocument =
+      BSONDocument("age" -> p.age, "name" -> p.name)
+  }
+
+  case class CustomException(msg: String) extends Exception(msg)
+}

--- a/iteratees/src/test/scala/common.scala
+++ b/iteratees/src/test/scala/common.scala
@@ -1,0 +1,31 @@
+object Common {
+  import scala.concurrent.{ Await, ExecutionContext }
+  import scala.concurrent.duration._
+  import reactivemongo.api.{ MongoDriver, MongoConnectionOptions }
+
+  implicit val ec = ExecutionContext.Implicits.global
+
+  val timeout = 10 seconds
+  val timeoutMillis = timeout.toMillis.toInt
+  val DefaultOptions = {
+    val opts = MongoConnectionOptions()
+
+    if (Option(System getProperty "test.enableSSL").exists(_ == "true")) {
+      opts.copy(sslEnabled = true, sslAllowsInvalidCert = true)
+    } else opts
+  }
+
+  lazy val driver = new MongoDriver
+  lazy val connection = driver.connection(
+    List("localhost:27017"), DefaultOptions)
+
+  lazy val db = {
+    val _db = connection("specs2-test-reactivemongo")
+    Await.ready(_db.drop, timeout)
+    _db
+  }
+
+  def closeDriver(): Unit = try {
+    driver.close()
+  } catch { case _: Throwable => () }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,4 +13,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.4")
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3-dcdc4774d19d1500437bc63e79c3abb8f99bcdb4")
 
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.5")
+
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.8")


### PR DESCRIPTION
Using the new streaming functions on `Cursor`, moving the `Iteratee` based functions outside of the core driver.