### PR TITLE
Add maxSize to collection stats results

### DIFF
--- a/driver/src/main/scala/api/commands/bson/instanceadministration.scala
+++ b/driver/src/main/scala/api/commands/bson/instanceadministration.scala
@@ -129,7 +129,8 @@ object BSONCollStatsImplicits {
         (for (kv <- indexSizes.elements) yield kv._1 -> kv._2.asInstanceOf[BSONInteger].value).toArray
       },
       doc.getAs[BSONBooleanLike]("capped").fold(false)(_.toBoolean),
-      doc.getAs[BSONNumberLike]("max").map(_.toLong))
+      doc.getAs[BSONNumberLike]("max").map(_.toLong),
+      doc.getAs[BSONNumberLike]("maxSize").map(_.toDouble))
   }
 }
 

--- a/driver/src/main/scala/api/commands/instanceadministration.scala
+++ b/driver/src/main/scala/api/commands/instanceadministration.scala
@@ -54,6 +54,7 @@ case class CollStats(scale: Option[Int] = None) extends CollectionCommand with C
  * @param indexSizes Size of specific indexes in bytes.
  * @param capped States if this collection is capped.
  * @param max The maximum number of documents of this collection, if capped.
+ * @param maxSize The maximum size in bytes (or in bytes / scale, if any) of this collection, if capped.
  */
 case class CollStatsResult(
   ns: String,
@@ -70,7 +71,8 @@ case class CollStatsResult(
   totalIndexSize: Int,
   indexSizes: Array[(String, Int)],
   capped: Boolean,
-  max: Option[Long])
+  max: Option[Long],
+  maxSize: Option[Double])
 
 case class DropIndexes(index: String) extends CollectionCommand with CommandWithResult[DropIndexesResult]
 

--- a/driver/src/test/scala/CollectionSpec.scala
+++ b/driver/src/test/scala/CollectionSpec.scala
@@ -1,4 +1,5 @@
 import reactivemongo.bson.{ BSONDocument, BSONString }
+import reactivemongo.api.commands.CollStatsResult
 import scala.concurrent.Await
 import scala.util.{ Try, Success, Failure }
 import org.specs2.mutable.{ Specification, Tags }
@@ -10,24 +11,33 @@ object CollectionSpec extends Specification with Tags {
 
   lazy val collection = db("somecollection_collectionspec")
 
+  val cappedMaxSize = 2 * 1024 * 1024
+
   "ReactiveMongo" should {
     "create a collection" in {
       collection.create() must beEqualTo(()).await(timeoutMillis)
     }
 
     "convert to capped" in {
-      collection.convertToCapped(2 * 1024 * 1024, None) must beEqualTo(()).
+      collection.convertToCapped(cappedMaxSize, None) must beEqualTo(()).
         await(timeoutMillis)
     }
 
-    "check if it's capped" in {
+    "check if it's capped (MongoDB <= 2.6)" in {
       // convertToCapped is async. Let's wait a little while before checking if it's done
       Await.result(reactivemongo.util.ExtendedFutures.DelayedFuture(4000, connection.actorSystem), timeout)
-      println("\n\n\t***** CHECKING \n\n")
-      val stats = Await.result(collection.stats, timeout)
-      println(stats)
-      stats.capped mustEqual true
-    }
+      collection.stats must beLike[CollStatsResult] {
+        case stats => stats.capped must beTrue and (stats.maxSize must beNone)
+      }.await(timeoutMillis)
+    } tag ("mongo2", "mongo26")
+
+    "check if it's capped (MongoDB >= 3.0)" in {
+      // convertToCapped is async. Let's wait a little while before checking if it's done
+      Await.result(reactivemongo.util.ExtendedFutures.DelayedFuture(4000, connection.actorSystem), timeout)
+      collection.stats must beLike[CollStatsResult] {
+        case stats => stats.capped must beTrue and (stats.maxSize must beSome(cappedMaxSize))
+      }.await(timeoutMillis)
+    } tag ("mongo3", "not_mongo26")
 
     "insert some docs then test lastError result and finally count" in {
       val lastError = Await.result(collection.insert(BSONDocument("name" -> BSONString("Jack"))), timeout)


### PR DESCRIPTION
The `maxSize` information was missing from the stats command results.
It can be useful for capped collections, for example to calculate the remaining available space in the collection.