### PR TITLE
MiMa integration

### DIFF
--- a/.travis_scripts/validate.sh
+++ b/.travis_scripts/validate.sh
@@ -49,5 +49,5 @@ if [ "$MONGODB_VER" = "3" ]; then
         SBT_OPTS="$SBT_OPTS -Dtest.enableSSL=true"
     fi
 fi
-
-sbt $SBT_OPTS "testOnly -- $TEST_OPTS"
+sbt ++$TRAVIS_SCALA_VERSION 
+sbt $SBT_OPTS ";mimaReportBinaryIssues ;testOnly -- $TEST_OPTS"

--- a/driver/src/main/scala/api/QueryOpts.scala
+++ b/driver/src/main/scala/api/QueryOpts.scala
@@ -18,13 +18,14 @@ package reactivemongo.api
 import org.jboss.netty.buffer.ChannelBuffer
 import reactivemongo.core.protocol.QueryFlags
 
-/* TODO: Remove?
+@deprecated(message = "Will be removed", since = "0.11.10")
 sealed trait SortOrder
+
+@deprecated(message = "Will be removed", since = "0.11.10")
 object SortOrder {
   case object Ascending extends SortOrder
   case object Descending extends SortOrder
 }
- */
 
 /**
  * A helper to make the query options.

--- a/driver/src/main/scala/api/commands/instanceadministration.scala
+++ b/driver/src/main/scala/api/commands/instanceadministration.scala
@@ -57,22 +57,45 @@ case class CollStats(scale: Option[Int] = None) extends CollectionCommand with C
  * @param maxSize The maximum size in bytes (or in bytes / scale, if any) of this collection, if capped.
  */
 case class CollStatsResult(
-  ns: String,
-  count: Int,
-  size: Double,
-  averageObjectSize: Option[Double],
-  storageSize: Double,
-  numExtents: Option[Int],
-  nindexes: Int,
-  lastExtentSize: Option[Int],
-  paddingFactor: Option[Double],
-  systemFlags: Option[Int],
-  userFlags: Option[Int],
-  totalIndexSize: Int,
-  indexSizes: Array[(String, Int)],
-  capped: Boolean,
-  max: Option[Long],
-  maxSize: Option[Double])
+    ns: String,
+    count: Int,
+    size: Double,
+    averageObjectSize: Option[Double],
+    storageSize: Double,
+    numExtents: Option[Int],
+    nindexes: Int,
+    lastExtentSize: Option[Int],
+    paddingFactor: Option[Double],
+    systemFlags: Option[Int],
+    userFlags: Option[Int],
+    totalIndexSize: Int,
+    indexSizes: Array[(String, Int)],
+    capped: Boolean,
+    max: Option[Long],
+    maxSize: Option[Double] = None) {
+
+  @deprecated(message = "Use [[copy]] with [[maxSize]]", since = "0.11.10")
+  def copy(
+    ns: String = this.ns,
+    count: Int = this.count,
+    size: Double = this.size,
+    averageObjectSize: Option[Double] = this.averageObjectSize,
+    storageSize: Double = this.storageSize,
+    numExtents: Option[Int] = this.numExtents,
+    nindexes: Int = this.nindexes,
+    lastExtentSize: Option[Int] = this.lastExtentSize,
+    paddingFactor: Option[Double] = this.paddingFactor,
+    systemFlags: Option[Int] = this.systemFlags,
+    userFlags: Option[Int] = this.userFlags,
+    totalIndexSize: Int = this.totalIndexSize,
+    indexSizes: Array[(String, Int)] = this.indexSizes,
+    capped: Boolean = this.capped,
+    max: Option[Long] = this.max): CollStatsResult = CollStatsResult(
+    ns, count, size, averageObjectSize, storageSize, numExtents, nindexes,
+    lastExtentSize, paddingFactor, systemFlags, userFlags, totalIndexSize,
+    indexSizes, capped, max)
+
+}
 
 case class DropIndexes(index: String) extends CollectionCommand with CommandWithResult[DropIndexesResult]
 

--- a/driver/src/main/scala/api/gridfs.scala
+++ b/driver/src/main/scala/api/gridfs.scala
@@ -113,14 +113,25 @@ class DefaultFileToSave(
   val filename: Option[String] = None,
   val contentType: Option[String] = None,
   val uploadDate: Option[Long] = None,
-  val metadata: BSONDocument = BSONDocument(),
+  val metadata: BSONDocument = BSONDocument.empty,
   val id: BSONValue = BSONObjectID.generate)
-    extends FileToSave[BSONSerializationPack.type, BSONValue] {
+    extends FileToSave[BSONSerializationPack.type, BSONValue] with Equals {
+
   val pack = BSONSerializationPack
+
+  def canEqual(that: Any): Boolean = that match {
+    case _: DefaultFileToSave => true
+    case _                    => false
+  }
+
+  def copy(filename: Option[String] = this.filename, contentType: Option[String] = this.contentType, uploadDate: Option[Long] = this.uploadDate, metadata: BSONDocument = this.metadata, id: BSONValue = this.id) = new DefaultFileToSave(filename, contentType, uploadDate, metadata, id)
+
 }
 
 /** Factory of [[DefaultFileToSave]]. */
 object DefaultFileToSave {
+  def unapply(that: DefaultFileToSave): Option[(Option[String], Option[String], Option[Long], BSONDocument, BSONValue)] = Some((that.filename, that.contentType, that.uploadDate, that.metadata, that.id))
+
   /** For backward compatibility. */
   sealed trait FileName[T] extends (T => Option[String]) {
     def apply(name: T): Option[String]

--- a/driver/src/main/scala/core/commands/authentication.scala
+++ b/driver/src/main/scala/core/commands/authentication.scala
@@ -257,6 +257,12 @@ object ScramSha1FinalNegociation
 
 // --- MongoDB CR authentication ---
 
+@deprecated(message = "See [[GetCrNonce]]", since = "0.11.10")
+object Getnonce extends Command[String] {
+  override def makeDocuments = GetCrNonce.makeDocuments
+  val ResultMaker = GetCrNonce.ResultMaker
+}
+
 /**
  * Getnonce Command for Mongo CR authentication.
  *
@@ -270,6 +276,29 @@ object GetCrNonce extends Command[String] {
       CommandError.checkOk(document, Some("getnonce")).
         toLeft(document.getAs[BSONString]("nonce").get.value)
   }
+}
+
+@deprecated(message = "See [[CrAuthenticate]]", since = "0.11.10")
+case class Authenticate(user: String, password: String, nonce: String)
+    extends Command[SuccessfulAuthentication] {
+
+  private val underlying = CrAuthenticate(user, password, nonce)
+
+  @deprecated(message =
+    "See [[CrAuthenticate.makeDocuments]]", since = "0.11.10")
+  override def makeDocuments = underlying.makeDocuments
+
+  @deprecated(message =
+    "See [[CrAuthenticate.ResultMaker]]", since = "0.11.10")
+  val ResultMaker = underlying.ResultMaker
+
+  @deprecated(message =
+    "See [[CrAuthenticate.pwdDigest]]", since = "0.11.10")
+  def pwdDigest = underlying.pwdDigest
+
+  @deprecated(message =
+    "See [[CrAuthenticate.key]]", since = "0.11.10")
+  def key = underlying.key
 }
 
 /**

--- a/driver/src/main/scala/core/nodeset.scala
+++ b/driver/src/main/scala/core/nodeset.scala
@@ -314,19 +314,10 @@ sealed trait Authenticating extends Authentication {
   def password: String
 }
 
-case class CrAuthenticating(db: String, user: String, password: String, nonce: Option[String]) extends Authenticating {
-  override def toString: String =
-    s"Authenticating($db, $user, ${nonce.map(_ => "<nonce>").getOrElse("<>")})"
-}
-
-case class ScramSha1Authenticating(
-  db: String, user: String, password: String,
-  randomPrefix: String, saslStart: String,
-  conversationId: Option[Int] = None,
-  serverSignature: Option[Array[Byte]] = None,
-  step: Int = 0) extends Authenticating
-
 object Authenticating {
+  @deprecated(message = "Use [[CrAuthenticating.apply]]", since = "0.11.10")
+  def apply(db: String, user: String, password: String, nonce: Option[String]): Authenticating = CrAuthenticating(db, user, password, nonce)
+
   def unapply(auth: Authenticating): Option[(String, String, String)] =
     auth match {
       case CrAuthenticating(db, user, pass, _) =>
@@ -339,6 +330,18 @@ object Authenticating {
         None
     }
 }
+
+case class CrAuthenticating(db: String, user: String, password: String, nonce: Option[String]) extends Authenticating {
+  override def toString: String =
+    s"Authenticating($db, $user, ${nonce.map(_ => "<nonce>").getOrElse("<>")})"
+}
+
+case class ScramSha1Authenticating(
+  db: String, user: String, password: String,
+  randomPrefix: String, saslStart: String,
+  conversationId: Option[Int] = None,
+  serverSignature: Option[Array[Byte]] = None,
+  step: Int = 0) extends Authenticating
 
 case class Authenticated(db: String, user: String) extends Authentication
 

--- a/project/ReactiveMongo.scala
+++ b/project/ReactiveMongo.scala
@@ -22,7 +22,9 @@ object BuildSettings {
     //fork in Test := true, // Don't share executioncontext between SBT CLI/tests
     scalacOptions in Compile ++= Seq(
       "-unchecked", "-deprecation", "-target:jvm-1.6", "-Ywarn-unused-import"),
-    scalacOptions in (Compile, doc) ++= Seq("-unchecked", "-deprecation", "-diagrams", "-implicits", "-skip-packages", "samples"),
+    scalacOptions in (Compile, doc) ++= Seq(
+      "-unchecked", "-deprecation", "-diagrams", "-implicits",
+      "-skip-packages", "samples"),
     scalacOptions in (Compile, doc) ++= Opts.doc.title("ReactiveMongo API"),
     scalacOptions in (Compile, doc) ++= Opts.doc.version(buildVersion),
     scalacOptions in Compile := {
@@ -36,14 +38,40 @@ object BuildSettings {
     mappings in (Compile, packageBin) ~= filter,
     mappings in (Compile, packageSrc) ~= filter,
     mappings in (Compile, packageDoc) ~= filter) ++
-  Publish.settings ++ Format.settings
+  Publish.settings ++ Format.settings ++ Publish.mimaSettings
+
 }
 
 object Publish {
+  import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
+  import com.typesafe.tools.mima.plugin.MimaKeys.{
+    binaryIssueFilters, previousArtifacts
+  }
+  import com.typesafe.tools.mima.core._, ProblemFilters._, Problem.ClassVersion
+
   @inline def env(n: String): String = sys.env.get(n).getOrElse(n)
 
   private val repoName = env("PUBLISH_REPO_NAME")
   private val repoUrl = env("PUBLISH_REPO_URL")
+
+  val previousVersion = "0.11.0"
+
+  val missingMethodInOld: ProblemFilter = {
+    case mmp @ MissingMethodProblem(_) if (
+      mmp.affectedVersion == ClassVersion.Old) => false
+
+    case _ => true
+  }  
+
+  val mimaSettings = mimaDefaultSettings ++ Seq(
+    previousArtifacts := {
+      if (crossPaths.value) {
+        Set(organization.value % s"${moduleName.value}_${scalaBinaryVersion.value}" % previousVersion)
+      } else {
+        Set(organization.value % moduleName.value % previousVersion)
+      }
+    },
+    binaryIssueFilters ++= Seq(missingMethodInOld))
 
   lazy val settings = Seq(
     publishMavenStyle := true,
@@ -160,6 +188,10 @@ object ReactiveMongoBuild extends Build {
   import Resolvers._
   import Dependencies._
   import sbtunidoc.{ Plugin => UnidocPlugin }
+  import com.typesafe.tools.mima.core._, ProblemFilters._, Problem.ClassVersion
+  import com.typesafe.tools.mima.plugin.MimaKeys.{
+    binaryIssueFilters, previousArtifacts
+  }
 
   val projectPrefix = "ReactiveMongo"
 
@@ -168,7 +200,8 @@ object ReactiveMongoBuild extends Build {
       s"$projectPrefix-Root",
       file("."),
       settings = buildSettings ++ (publishArtifact := false) ).
-    settings(UnidocPlugin.unidocSettings: _*).
+      settings(UnidocPlugin.unidocSettings: _*).
+      settings(previousArtifacts := Set.empty).
     aggregate(driver, bson, bsonmacros)
 
   lazy val driver = Project(
@@ -183,6 +216,215 @@ object ReactiveMongoBuild extends Build {
         commonsCodec,
         shapelessTest,
         specs) ++ logApi,
+      binaryIssueFilters ++= {
+        import ProblemFilters.{ exclude => x }
+        @inline def mmp(s: String) = x[MissingMethodProblem](s)
+        @inline def imt(s: String) = x[IncompatibleMethTypeProblem](s)
+        @inline def fmp(s: String) = x[FinalMethodProblem](s)
+        @inline def irt(s: String) = x[IncompatibleResultTypeProblem](s)
+        @inline def mtp(s: String) = x[MissingTypesProblem](s)
+        @inline def mcp(s: String) = x[MissingClassProblem](s)
+
+        Seq(
+          x[IncompatibleTemplateDefProblem](
+            "reactivemongo.core.actors.MongoDBSystem"),
+          mcp("reactivemongo.core.actors.RequestIds"),
+          mmp("reactivemongo.api.CollectionMetaCommands.drop"),
+          mmp("reactivemongo.api.DB.coll"),
+          mmp("reactivemongo.api.DB.coll$default$2"),
+          mmp("reactivemongo.api.DB.defaultReadPreference"),
+          mmp("reactivemongo.api.DB.coll$default$4"),
+          mmp("reactivemongo.api.DBMetaCommands.serverStatus"),
+          mmp(
+            "reactivemongo.api.collections.BatchCommands.DistinctResultReader"),
+          mmp(
+            "reactivemongo.api.collections.BatchCommands.AggregationFramework"),
+          mmp(
+            "reactivemongo.api.collections.BatchCommands.FindAndModifyReader"),
+          mmp(
+            "reactivemongo.api.collections.BatchCommands.DistinctWriter"),
+          mmp(
+            "reactivemongo.api.collections.BatchCommands.FindAndModifyCommand"),
+          mmp(
+            "reactivemongo.api.collections.BatchCommands.AggregateWriter"),
+          mmp(
+            "reactivemongo.api.collections.BatchCommands.DistinctCommand"),
+          mmp(
+            "reactivemongo.api.collections.BatchCommands.AggregateReader"),
+          irt("reactivemongo.api.commands.Upserted._id"),
+          imt("reactivemongo.api.commands.Upserted.this"),
+          imt("reactivemongo.api.commands.Upserted.copy"),
+          irt("reactivemongo.api.Cursor.logger"),
+          mcp("reactivemongo.api.commands.tst2"),
+          mcp("reactivemongo.api.commands.tst2$"),
+          mtp("reactivemongo.api.commands.DefaultWriteResult"),
+          mmp("reactivemongo.api.commands.DefaultWriteResult.fillInStackTrace"),
+          mmp("reactivemongo.api.commands.DefaultWriteResult.isUnauthorized"),
+          mmp("reactivemongo.api.commands.DefaultWriteResult.getMessage"),
+          irt("reactivemongo.api.commands.DefaultWriteResult.originalDocument"),
+          irt("reactivemongo.core.commands.Getnonce.ResultMaker"),
+          irt("reactivemongo.core.protocol.RequestEncoder.logger"),
+          mmp("reactivemongo.api.MongoConnection#MonitorActor.killed_="),
+          mmp("reactivemongo.api.MongoConnection#MonitorActor.primaryAvailable_="),
+          mmp("reactivemongo.api.MongoConnection#MonitorActor.killed"),
+          mmp(
+            "reactivemongo.api.MongoConnection#MonitorActor.primaryAvailable"),
+          mmp("reactivemongo.api.collections.GenericCollection#Mongo26WriteCommand._debug"),
+          fmp(
+            "reactivemongo.api.commands.AggregationFramework#Project.toString"),
+          fmp(
+            "reactivemongo.api.commands.AggregationFramework#Redact.toString"),
+          fmp("reactivemongo.api.commands.AggregationFramework#Sort.toString"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Limit.n"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Limit.name"),
+          mtp("reactivemongo.api.commands.AggregationFramework$Limit"),
+          irt("reactivemongo.api.gridfs.DefaultFileToSave.filename"),
+          irt("reactivemongo.api.gridfs.DefaultReadFile.filename"),
+          irt("reactivemongo.api.gridfs.DefaultReadFile.length"),
+          irt("reactivemongo.api.gridfs.BasicMetadata.filename"),
+          irt("reactivemongo.api.gridfs.package.logger"),
+          mtp("reactivemongo.api.MongoConnectionOptions$"),
+          mmp("reactivemongo.api.MongoConnectionOptions.apply"),
+          mmp("reactivemongo.api.MongoConnectionOptions.copy"),
+          mmp("reactivemongo.api.MongoConnectionOptions.this"),
+          fmp("reactivemongo.api.commands.AggregationFramework#Group.toString"),
+          mcp("reactivemongo.api.commands.tst2$Toto"),
+          fmp("reactivemongo.api.commands.AggregationFramework#Match.toString"),
+          mmp("reactivemongo.api.commands.WriteResult.originalDocument"),
+          fmp(
+            "reactivemongo.api.commands.AggregationFramework#GeoNear.toString"),
+          irt("reactivemongo.api.gridfs.ComputedMetadata.length"),
+          irt("reactivemongo.core.commands.Authenticate.ResultMaker"),
+          mtp("reactivemongo.api.gridfs.DefaultFileToSave"),
+          mmp("reactivemongo.api.gridfs.DefaultFileToSave.productElement"),
+          mmp("reactivemongo.api.gridfs.DefaultFileToSave.productArity"),
+          mmp("reactivemongo.api.gridfs.DefaultFileToSave.productIterator"),
+          mmp("reactivemongo.api.gridfs.DefaultFileToSave.productPrefix"),
+          imt("reactivemongo.api.gridfs.DefaultFileToSave.this"),
+          mtp("reactivemongo.api.gridfs.DefaultFileToSave$"),
+          imt("reactivemongo.api.gridfs.DefaultReadFile.apply"),
+          imt("reactivemongo.api.gridfs.DefaultReadFile.copy"),
+          imt("reactivemongo.api.gridfs.DefaultReadFile.this"),
+          mmp("reactivemongo.api.gridfs.DefaultFileToSave.apply"),
+          imt("reactivemongo.api.gridfs.DefaultFileToSave.copy"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Skip.n"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Skip.name"),
+          mtp("reactivemongo.api.commands.AggregationFramework$Skip"),
+          mcp("reactivemongo.api.commands.AggregationFramework$PipelineStage"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Aggregate.needsCursor"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Aggregate.cursorOptions"),
+          mtp("reactivemongo.api.commands.WriteResult"),
+          mtp("reactivemongo.api.commands.UpdateWriteResult"),
+          mmp("reactivemongo.api.commands.UpdateWriteResult.fillInStackTrace"),
+          mmp("reactivemongo.api.commands.UpdateWriteResult.isUnauthorized"),
+          mmp("reactivemongo.api.commands.UpdateWriteResult.getMessage"),
+          mmp(
+            "reactivemongo.api.commands.UpdateWriteResult.isNotAPrimaryError"),
+          irt("reactivemongo.api.commands.UpdateWriteResult.originalDocument"),
+          mtp("reactivemongo.api.commands.AggregationFramework$Match$"),
+          mtp("reactivemongo.api.commands.AggregationFramework$Redact$"),
+          mcp("reactivemongo.api.commands.AggregationFramework$DocumentStageCompanion"),
+          mtp("reactivemongo.api.commands.AggregationFramework$Project$"),
+          mtp("reactivemongo.api.commands.AggregationFramework$Sort$"),
+          mtp("reactivemongo.core.commands.Authenticate$"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Unwind.prefixedField"),
+          mmp("reactivemongo.core.commands.Authenticate.apply"),
+          mmp("reactivemongo.core.commands.Authenticate.apply"),
+          mtp("reactivemongo.api.commands.LastError$"),
+          mmp("reactivemongo.api.commands.LastError.apply"),
+          irt("reactivemongo.api.commands.LastError.originalDocument"),
+          mmp("reactivemongo.api.commands.LastError.copy"),
+          mmp("reactivemongo.api.commands.LastError.this"),
+          mtp("reactivemongo.api.commands.CollStatsResult$"),
+          mmp("reactivemongo.api.commands.CollStatsResult.apply"),
+          mmp("reactivemongo.api.commands.CollStatsResult.this"),
+          mmp("reactivemongo.api.commands.GetLastError#TagSet.s"),
+          mmp("reactivemongo.api.commands.FindAndModifyCommand#FindAndModify.apply"),
+          mmp("reactivemongo.api.commands.FindAndModifyCommand#FindAndModify.this"),
+          mmp("reactivemongo.api.commands.FindAndModifyCommand#FindAndModify.copy"),
+          mmp("reactivemongo.api.commands.FindAndModifyCommand#Update.copy"),
+          mmp("reactivemongo.api.commands.FindAndModifyCommand#Update.this"),
+          mmp("reactivemongo.api.commands.FindAndModifyCommand#Update.apply"),
+          irt("reactivemongo.api.commands.LastError.originalDocument"),
+          imt("reactivemongo.api.commands.AggregationFramework#Group.apply"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Redact.apply"),
+          imt("reactivemongo.api.commands.Upserted.apply"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Match.apply"),
+          irt("reactivemongo.api.commands.AggregationFramework#Sort.apply"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Sort.apply"),
+          mmp("reactivemongo.api.commands.AggregationFramework#GeoNear.apply"),
+          mmp(
+            "reactivemongo.api.commands.AggregationFramework#GeoNear.andThen"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Sort.unapply"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Sort.copy"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Sort.document"),
+          mcp("reactivemongo.api.commands.AggregationFramework$PipelineStageDocumentProducer"),
+          mmp("reactivemongo.api.commands.AggregationFramework.PipelineStageDocumentProducer"),
+          mcp("reactivemongo.api.commands.AggregationFramework$PipelineStageDocumentProducer$"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Group.andThen"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Group.this"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Group.copy"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Group.document"),
+          imt("reactivemongo.api.commands.AggregationFramework#Sort.this"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Sort.copy"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Sort.document"),
+          mcp("reactivemongo.api.commands.CursorCommand"),
+          mmp(
+            "reactivemongo.api.commands.AggregationFramework#Project.document"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Match.document"),
+          mmp("reactivemongo.api.collections.bson.BSONQueryBuilder.copy"),
+          mmp("reactivemongo.api.collections.bson.BSONQueryBuilder.this"),
+          mmp("reactivemongo.api.collections.bson.BSONQueryBuilder$"),
+          mmp("reactivemongo.api.collections.bson.BSONQueryBuilder.apply"),
+          mmp("reactivemongo.api.MongoConnection.ask"),
+          mmp("reactivemongo.api.MongoConnection.ask"),
+          mmp("reactivemongo.api.MongoConnection.waitForPrimary"),
+          mmp(
+            "reactivemongo.api.commands.AggregationFramework#Aggregate.apply"),
+          mtp("reactivemongo.api.commands.AggregationFramework$Aggregate"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Aggregate.copy"),
+          irt("reactivemongo.api.commands.AggregationFramework#Aggregate.pipeline"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Aggregate.this"),
+          mmp("reactivemongo.api.collections.GenericQueryBuilder.copy"),
+          mcp("reactivemongo.api.commands.AggregationFramework$AggregateCursorOptions$"),
+          mcp("reactivemongo.api.commands.AggregationFramework$AggregateCursorOptions"),
+          mmp("reactivemongo.api.commands.AggregationFramework.AggregateCursorOptions"),
+          mtp("reactivemongo.api.commands.AggregationFramework$Group$"),
+          mtp("reactivemongo.api.collections.bson.BSONQueryBuilder$"),
+          x[IncompatibleTemplateDefProblem](
+            "reactivemongo.core.nodeset.Authenticating"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Group.compose"),
+          mtp("reactivemongo.api.commands.AggregationFramework$GeoNear$"),
+          mmp(
+            "reactivemongo.api.commands.AggregationFramework#GeoNear.compose"),
+          mcp("reactivemongo.api.commands.AggregationFramework$DocumentStage"),
+          mtp("reactivemongo.api.commands.AggregationFramework$Redact"),
+          mtp("reactivemongo.api.commands.AggregationFramework$GeoNear"),
+          mtp("reactivemongo.api.commands.AggregationFramework$Unwind"),
+          mtp("reactivemongo.api.commands.AggregationFramework$Project"),
+          mtp("reactivemongo.api.commands.AggregationFramework$Out"),
+          mtp("reactivemongo.api.commands.AggregationFramework$Match"),
+          mmp("reactivemongo.api.commands.DefaultWriteResult.isNotAPrimaryError"),
+          mtp("reactivemongo.api.commands.AggregationFramework$Sort"),
+          mtp("reactivemongo.api.commands.AggregationFramework$Group"),
+          mmp("reactivemongo.api.commands.AggregationFramework#GeoNear.name"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Redact.name"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Unwind.name"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Project.name"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Out.name"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Match.name"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Sort.name"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Group.name"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Group.apply"),
+          mmp("reactivemongo.api.commands.AggregationFramework#GeoNear.this"),
+          mmp("reactivemongo.api.commands.AggregationFramework#GeoNear.copy"),
+          mmp(
+            "reactivemongo.api.commands.AggregationFramework#GeoNear.document"),
+          mtp("reactivemongo.core.nodeset.Authenticating$"),
+          mmp("reactivemongo.api.commands.AggregationFramework#Project.apply"),
+          mmp(
+            "reactivemongo.api.commands.AggregationFramework#Redact.document"))
+      },
       testOptions in Test += Tests.Cleanup(cl => {
         import scala.language.reflectiveCalls
         val c = cl.loadClass("Common$")
@@ -195,7 +437,11 @@ object ReactiveMongoBuild extends Build {
     s"$projectPrefix-BSON",
     file("bson"),
     settings = buildSettings).
-    settings(libraryDependencies += specs)
+    settings(
+      libraryDependencies += specs,
+      binaryIssueFilters ++= Seq(
+        ProblemFilters.exclude[MissingTypesProblem](
+          "reactivemongo.bson.BSONTimestamp$")))
 
   lazy val bsonmacros = Project(
     s"$projectPrefix-BSON-Macros",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,3 +12,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.4")
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3-dcdc4774d19d1500437bc63e79c3abb8f99bcdb4")
+
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.8")


### PR DESCRIPTION
- In class `reactivemongo.api.commands.Upserted`;
  * constructor has changed; was `(Int, java.lang.Object)`, is now: `(Int, reactivemongo.bson.BSONValue)`
  * method `_id()`  has now a different result type; was: `java.lang.Object`, is now: `reactivemongo.bson.BSONValue`
- In class `reactivemongo.api.commands.AggregationFramework#Limit`;
  * method `n()` is removed
  * method `name()` is removed
- In class `reactivemongo.api.commands.AggregationFramework#Limit`;
  * method `n()` is removed
  * method `name()` is removed
- In class `reactivemongo.api.commands.AggregationFramework#Skip`;
  * method `n()` is removed
  * method `name()` is removed
- method `length()` in interface `reactivemongo.api.gridfs.ComputedMetadata` has now a different result type; was: `Int`, is now: `Long`
- Class `reactivemongo.core.actors.MongoDBSystem` has changed to trait.
- The type hierarchy of class `reactivemongo.api.commands.DefaultWriteResult` has changed in new version; no longer inherits from `java.lang.Exception`.
  * method `fillInStackTrace()` is removed
  * method `isUnauthorized()` is removed
  * method `getMessage()` is removed
  * method `isNotAPrimaryError()` is removed
- The type hierarchy of class `reactivemongo.api.commands.UpdateWriteResult` has changed in new version. No longer inherits from `java.lang.Exception`;
  * method `fillInStackTrace()` is removed
  * method `isUnauthorized()` is removed
  * method `getMessage()` is removed
- method `filename()` in class `reactivemongo.api.gridfs.DefaultFileToSave` has now a different result type; was: `String`, is now: `Option[String]`.
- In class `reactivemongo.api.gridfs.DefaultReadFile`;
  * field `length` in  has now a different result type; was: `Int`, is now: `Long`;
  * field `filename` has now a different result type; was: `String`, is now: `Option[String]`.
- The method `filename()` in interface `reactivemongo.api.gridfs.BasicMetadata` has now a different result type; was: `String`, is now: `Option[String]`
- In the case class `reactivemongo.api.MongoConnectionOptions`, the constructor has 2 extra properties `writeConcern` and `readPreference`.
- The case class `reactivemongo.api.gridfs.DefaultFileToSave` has changed to class.
- In `reactivemongo.api.commands.AggregationFramework`;
  * the type `PipelineStage` is removed
  * the type `DocumentStage` is removed
  * the type `DocumentStageCompanion` is removed
  * the type `PipelineStageDocumentProducer` is removed
  * the types of the parameter for the constructor of `Aggregate` have changed
  * the type `AggregateCursorOptions` is removed
- In the class `reactivemongo.api.commands.AggregationFramework#Aggregate`;
  * method `needsCursor()` is removed
  * method `cursorOptions()` is removed
- The type hierarchy of trait `reactivemongo.api.commands.WriteResult` has changed in new version. No longer inherits from `reactivemongo.core.errors.DatabaseException`, `scala.util.control.NoStackTrace`, `reactivemongo.core.errors.ReactiveMongoException`
- For the object `reactivemongo.core.commands.Authenticate`;
  * The type hierarchy of has changed in new version. No longer inherits from `reactivemongo.core.commands.BSONCommandResultMaker` and `reactivemongo.core.commands.CommandResultMaker`.
  * method `apply(reactivemongo.bson.BSONDocument)` is removed
  * method `apply(reactivemongo.core.protocol.Response)` is removed
- For the type `reactivemongo.api.commands.LastError`, the properties `writeErrors` and `writeConcernError` have been added.
- In the case class `reactivemongo.api.commands.CollStatsResult`, the field `maxSize` has been added.
- The field `s` in class `reactivemongo.api.commands.GetLastError#TagSet` is renamed to `tag`
- In the object `reactivemongo.api.commands.FindAndModifyCommand#FindAndModify`, the parameter types of the method `apply` have changed.
- In the class `reactivemongo.api.commands.FindAndModifyCommand#Update`, the type of the parameter `update` is now `Document`; was `java.lang.Object`.
- In the class `reactivemongo.api.MongoConnection`;
  * method `ask(reactivemongo.core.protocol.CheckedWriteRequest)` is removed
  * method `ask(reactivemongo.core.protocol.RequestMaker,Boolean)` is removed
  * method `waitForPrimary(scala.concurrent.duration.FiniteDuration)` is removed
- In trait `reactivemongo.api.collections.GenericQueryBuilder`, the field `maxTimeMsOption` is added.
- The field `prefixedField` is removed from class `reactivemongo.api.commands.AggregationFramework#Unwind`.
- The field `name` is removed from the pipeline stages for `reactivemongo.api.commands.AggregationFramework`.
- The interface `reactivemongo.api.commands.CursorCommand` does not have a correspondent in new version.
- The field `maxTimeMsOption` is added to the type `reactivemongo.api.collections.bson.BSONQueryBuilder`.
- The declaration of class `reactivemongo.core.nodeset.Authenticating` has changed to interface.