### PR TITLE
Remove deprecated macro API usage

### DIFF
--- a/macros/src/main/scala-2.10/macros.scala
+++ b/macros/src/main/scala-2.10/macros.scala
@@ -1,0 +1,368 @@
+package reactivemongo.bson
+
+import reactivemongo.bson.Macros.Annotations.{ Ignore, Key }
+import reactivemongo.bson.Macros.Options.SaveSimpleName
+
+import scala.reflect.macros.Context
+
+/**
+  * User: andraz
+  * Date: 2/21/13
+  * Time: 6:51 PM
+  */
+private object MacroImpl {
+  def reader[A: c.WeakTypeTag, Opts: c.WeakTypeTag](c: Context): c.Expr[BSONDocumentReader[A]] =
+    c.universe.reify(
+      new BSONDocumentReader[A] {
+        def read(document: BSONDocument): A =
+          Helper[A, Opts](c).readBody.splice
+      })
+
+  def writer[A: c.WeakTypeTag, Opts: c.WeakTypeTag](c: Context): c.Expr[BSONDocumentWriter[A]] =
+    c.universe.reify(
+      new BSONDocumentWriter[A] {
+        def write(document: A): BSONDocument =
+          Helper[A, Opts](c).writeBody.splice
+      })
+
+  def handler[A: c.WeakTypeTag, Opts: c.WeakTypeTag](c: Context): c.Expr[BSONDocumentReader[A] with BSONDocumentWriter[A] with BSONHandler[BSONDocument, A]] = {
+    val helper = Helper[A, Opts](c)
+    c.universe.reify(
+      new BSONDocumentReader[A] with BSONDocumentWriter[A] with BSONHandler[BSONDocument, A] {
+        def read(document: BSONDocument): A = helper.readBody.splice
+
+        def write(document: A): BSONDocument = helper.writeBody.splice
+      })
+  }
+
+  private def Helper[A: c.WeakTypeTag, Opts: c.WeakTypeTag](c: Context) = new Helper[c.type, A](c) {
+    val A = c.weakTypeOf[A]
+    val Opts = c.weakTypeOf[Opts]
+  }
+
+  private abstract class Helper[C <: Context, A](val c: C) {
+    import c.universe._
+
+    protected def A: c.Type
+    protected def Opts: c.Type
+
+    lazy val readBody: c.Expr[A] = {
+      val writer = unionTypes map { types =>
+        val cases = types map { typ =>
+          val pattern = if (hasOption[SaveSimpleName])
+            Literal(Constant(typ.typeSymbol.name.decodedName.toString))
+          else
+            Literal(Constant(typ.typeSymbol.fullName)) //todo
+
+          val body = readBodyFromImplicit(typ)
+          CaseDef(pattern, body)
+        }
+        val className = c.parse("""document.getAs[String]("className").get""")
+        Match(className, cases)
+      } getOrElse readBodyConstruct(A)
+
+      val result = c.Expr[A](writer)
+
+      if (hasOption[Macros.Options.Verbose]) {
+        c.echo(c.enclosingPosition, show(result))
+      }
+      result
+    }
+
+    lazy val writeBody: c.Expr[BSONDocument] = {
+      val writer = unionTypes map { types =>
+        val cases = types map { typ =>
+          val pattern = Bind(newTermName("document"), Typed(Ident(nme.WILDCARD), TypeTree(typ)))
+          val body = writeBodyFromImplicit(typ)
+          CaseDef(pattern, body)
+        }
+        Match(Ident("document"), cases)
+      } getOrElse writeBodyConstruct(A)
+
+      val result = c.Expr[BSONDocument](writer)
+
+      if (hasOption[Macros.Options.Verbose]) {
+        c.echo(c.enclosingPosition, show(result))
+      }
+      result
+    }
+
+    private def readBodyFromImplicit(A: c.Type) = {
+      val reader = c.inferImplicitValue(appliedType(readerType, List(A)))
+      if (!reader.isEmpty)
+        Apply(Select(reader, "read"), List(Ident("document")))
+      else
+        readBodyConstruct(A)
+    }
+
+    private def readBodyConstruct(implicit A: c.Type) = {
+      if (isSingleton(A))
+        readBodyConstructSingleton
+      else
+        readBodyConstructClass
+    }
+
+    private def readBodyConstructSingleton(implicit A: c.Type) = {
+      val sym = A match {
+        case SingleType(_, sym) => sym
+        case TypeRef(_, sym, _) => sym
+        case _                  => c.abort(c.enclosingPosition, s"Something weird is going on with '$A'. Should be a singleton but can't parse it")
+      }
+      val name = stringToTermName(sym.name.toString) //this is ugly but quite stable compared to other attempts
+      Ident(name)
+    }
+
+    private def readBodyConstructClass(implicit A: c.Type) = {
+      val (constructor, _) = matchingApplyUnapply
+
+      val values = constructor.paramss.head map {
+        param =>
+          val sig = param.typeSignature
+          val optTyp = optionTypeParameter(sig)
+          val typ = optTyp getOrElse sig
+
+          if (optTyp.isDefined) {
+            Apply(
+              TypeApply(
+                Select(Ident("document"), "getAs"),
+                List(TypeTree(typ))),
+              List(Literal(Constant(paramName(param)))))
+          } else {
+            val getter = Apply(
+              TypeApply(
+                Select(Ident("document"), "getAsTry"),
+                List(TypeTree(typ))),
+              List(Literal(Constant(paramName(param)))))
+            Select(getter, "get")
+          }
+
+      }
+
+      val constructorTree = Select(Ident(companion.name.toString), "apply")
+      Apply(constructorTree, values)
+    }
+
+    private def writeBodyFromImplicit(A: c.Type) = {
+      val writer = c.inferImplicitValue(appliedType(writerType, List(A)))
+      if (!writer.isEmpty) {
+        val doc = Apply(Select(writer, "write"), List(Ident("document")))
+
+        classNameTree(A) map { className =>
+          val nameE = c.Expr[(String, BSONString)](className)
+          val docE = c.Expr[BSONDocument](doc)
+
+          reify {
+            docE.splice ++ BSONDocument(Seq((nameE.splice)))
+          }.tree
+        } getOrElse doc
+      } else writeBodyConstruct(A)
+    }
+
+    private def writeBodyConstruct(A: c.Type): c.Tree = {
+      if (isSingleton(A)) writeBodyConstructSingleton(A)
+      else writeBodyConstructClass(A)
+    }
+
+    private def writeBodyConstructSingleton(A: c.Type): c.Tree = (
+      classNameTree(A) map { className =>
+        val nameE = c.Expr[(String, BSONString)](className)
+        reify { BSONDocument(Seq((nameE.splice))) }
+      } getOrElse reify { BSONDocument.empty }
+      ).tree
+
+    private def writeBodyConstructClass(A: c.Type): c.Tree = {
+      val (constructor, deconstructor) = matchingApplyUnapply(A)
+      val types = unapplyReturnTypes(deconstructor)
+      val constructorParams = constructor.paramss.head
+
+      val tuple = Ident(newTermName("tuple"))
+      val (optional, required) = constructorParams.zipWithIndex.filterNot(p => ignoreField(p._1)) zip types partition (t => isOptionalType(t._2))
+      val values = required map {
+        case ((param, i), typ) =>
+          val neededType = appliedType(writerType, List(typ))
+          val writer = c.inferImplicitValue(neededType)
+          if (writer.isEmpty) c.abort(c.enclosingPosition, s"Implicit $typ for '$param' not found")
+          val tuple_i = if (types.length == 1) tuple else Select(tuple, "_" + (i + 1))
+          val bs_value = c.Expr[BSONValue](Apply(Select(writer, "write"), List(tuple_i)))
+          val name = c.literal(paramName(param))
+          reify((name.splice, bs_value.splice): (String, BSONValue)).tree
+      }
+
+      val appends = optional map {
+        case ((param, i), optType) =>
+          val typ = optionTypeParameter(optType).get
+          val neededType = appliedType(writerType, List(typ))
+          val writer = c.inferImplicitValue(neededType)
+          if (writer.isEmpty) c.abort(c.enclosingPosition, s"Implicit $typ for '$param' not found")
+          val tuple_i = if (types.length == 1) tuple else Select(tuple, "_" + (i + 1))
+          val bs_value = c.Expr[BSONValue](Apply(Select(writer, "write"), List(Select(tuple_i, "get"))))
+          val name = c.literal(paramName(param))
+          If(
+            Select(tuple_i, "isDefined"),
+            Apply(Select(Ident("buf"), "$plus$colon$eq"), List(reify((name.splice, bs_value.splice)).tree)),
+            EmptyTree)
+      }
+
+      val mkBSONdoc = Apply(bsonDocPath, values ++ classNameTree(A))
+
+      val writer = {
+        if (optional.isEmpty) List(mkBSONdoc)
+        else List(
+          ValDef(Modifiers(), newTermName("bson"), TypeTree(), mkBSONdoc),
+          c.parse("var buf = scala.collection.immutable.Stream[(String,reactivemongo.bson.BSONValue)]()")) ++ appends :+ c.parse("bson.add(reactivemongo.bson.BSONDocument(buf))")
+      }
+
+      val unapplyTree = Select(Ident(companion(A).name.toString), "unapply")
+      val invokeUnapply = Select(Apply(unapplyTree, List(Ident(newTermName("document")))), "get")
+      val tupleDef = ValDef(Modifiers(), newTermName("tuple"), TypeTree(), invokeUnapply)
+
+      if (values.length + appends.length > 0) {
+        Block((tupleDef :: writer): _*)
+      } else writer.head
+    }
+
+    private def classNameTree(A: c.Type) = {
+      if (hasOption[Macros.Options.SaveClassName]) Some {
+        val name = if (hasOption[Macros.Options.SaveSimpleName])
+          c.literal(A.typeSymbol.name.decodedName.toString)
+        else
+          c.literal(A.typeSymbol.fullName)
+
+        reify("className", BSONStringHandler.write(name.splice)).tree
+      }
+      else None
+    }
+
+    private lazy val unionTypes: Option[List[c.Type]] =
+      parseUnionTypes orElse parseAllImplementationTypes
+
+    private def parseUnionTypes: Option[List[c.Type]] = {
+      val unionOption = c.typeOf[Macros.Options.UnionType[_]]
+      val union = c.typeOf[Macros.Options.\/[_, _]]
+
+      def parseUnionTree(tree: Type): List[Type] = {
+        if (tree <:< union) {
+          tree match {
+            case TypeRef(_, _, List(a, b)) => parseUnionTree(a) ::: parseUnionTree(b)
+          }
+        } else List(tree)
+      }
+
+      val tree = Opts match {
+        case t @ TypeRef(_, _, lst) if t <:< unionOption =>
+          lst.headOption
+
+        case RefinedType(types, _) =>
+          types.filter(_ <:< unionOption).flatMap { case TypeRef(_, _, args) => args }.headOption
+
+        case _ => None
+      }
+      tree map { t => parseUnionTree(t) }
+    }
+
+    private def parseAllImplementationTypes: Option[List[Type]] = {
+      if (Opts <:< typeOf[Macros.Options.AllImplementations]) {
+        Some(allImplementations(A).toList)
+      } else None
+    }
+
+    private def hasOption[O: c.TypeTag]: Boolean = Opts <:< typeOf[O]
+
+    private def unapplyReturnTypes(deconstructor: c.universe.MethodSymbol): List[c.Type] = {
+      val opt = deconstructor.returnType match {
+        case TypeRef(_, _, Nil) => Some(Nil)
+        case TypeRef(_, _, args) =>
+          args.head match {
+            case t @ TypeRef(_, _, Nil) => Some(List(t))
+            case typ @ TypeRef(_, t, args) =>
+              Some(
+                if (t.name.toString.matches("Tuple\\d\\d?")) args else List(typ))
+            case _ => None
+          }
+        case _ => None
+      }
+      opt getOrElse c.abort(c.enclosingPosition, "something wrong with unapply type")
+    }
+
+    //Some(A) for Option[A] else None
+    private def optionTypeParameter(implicit A: c.Type): Option[c.Type] = {
+      if (isOptionalType(A))
+        A match {
+          case TypeRef(_, _, args) => args.headOption
+          case _                   => None
+        }
+      else None
+    }
+
+    private def isOptionalType(implicit A: c.Type): Boolean =
+      (c.typeOf[Option[_]].typeConstructor == A.typeConstructor)
+
+    private def bsonDocPath: c.universe.Select = Select(Select(
+      Ident(newTermName("reactivemongo")), "bson"), "BSONDocument")
+
+    private def paramName(param: c.Symbol): String = {
+      param.annotations.collect {
+        case ann if ann.tpe =:= typeOf[Key] =>
+          ann.scalaArgs.collect {
+            case l: Literal => l.value.value
+          }.collect {
+            case value: String => value
+          }
+      }.flatten.headOption getOrElse param.name.toString
+    }
+
+    private def ignoreField(param: c.Symbol): Boolean =
+      param.annotations.exists(ann =>
+        ann.tpe =:= typeOf[Ignore] || ann.tpe =:= typeOf[transient])
+
+    private def allSubclasses(A: Symbol): Set[Symbol] = {
+      val sub = A.asClass.knownDirectSubclasses
+      val subsub = sub flatMap allSubclasses
+      subsub ++ sub + A
+    }
+
+    private def allImplementations(A: Type) =
+      allSubclasses(A.typeSymbol).map(_.asClass).
+        filterNot(_.isAbstractClass).map(_.toType)
+
+    private def applyMethod(implicit A: c.Type): c.universe.Symbol =
+      companion(A).typeSignature.declaration(stringToTermName("apply")) match {
+        case NoSymbol => c.abort(c.enclosingPosition, s"No apply function found for $A")
+        case s        => s
+      }
+
+    private def unapplyMethod(implicit A: c.Type): c.universe.MethodSymbol =
+      companion(A).typeSignature.declaration(stringToTermName("unapply")) match {
+        case NoSymbol => c.abort(c.enclosingPosition, s"No unapply function found for $A")
+        case s        => s.asMethod
+      }
+
+    private def matchingApplyUnapply(implicit A: c.Type): (c.universe.MethodSymbol, c.universe.MethodSymbol) = {
+      val applySymbol = applyMethod(A)
+      val unapply = unapplyMethod(A)
+
+      val alternatives = applySymbol.asTerm.alternatives map (_.asMethod)
+      val u = unapplyReturnTypes(unapply)
+      val applys = alternatives filter { alt =>
+        val sig = alt.paramss.head.map(_.typeSignature)
+        sig.size == u.size && sig.zip(u).forall {
+          case (left, right) => left =:= right
+        }
+      }
+
+      val apply = applys.headOption getOrElse c.abort(c.enclosingPosition, "No matching apply/unapply found")
+      (apply, unapply)
+    }
+
+    type Reader[A] = BSONReader[_ <: BSONValue, A]
+    type Writer[A] = BSONWriter[A, _ <: BSONValue]
+
+    private def isSingleton(t: Type): Boolean = t <:< typeOf[Singleton]
+
+    private def writerType: c.Type = typeOf[Writer[_]].typeConstructor
+
+    private def readerType: c.Type = typeOf[Reader[_]].typeConstructor
+
+    private def companion(implicit A: c.Type): c.Symbol = A.typeSymbol.companionSymbol
+  }
+}

--- a/macros/src/main/scala-2.11/macros.scala
+++ b/macros/src/main/scala-2.11/macros.scala
@@ -1,45 +1,37 @@
 package reactivemongo.bson
 
+import reactivemongo.bson.Macros.Annotations.{ Ignore, Key }
 import reactivemongo.bson.Macros.Options.SaveSimpleName
 
-import collection.mutable.ListBuffer
-import reactivemongo.bson.Macros.Annotations.{ Key, Ignore }
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox.Context
 
 /**
- * User: andraz
- * Date: 2/21/13
- * Time: 6:51 PM
- */
+  * User: andraz
+  * Date: 2/21/13
+  * Time: 6:51 PM
+  */
 private object MacroImpl {
-  def reader[A: c.WeakTypeTag, Opts: c.WeakTypeTag](c: Context): c.Expr[BSONDocumentReader[A]] = {
-    val h = Helper[A, Opts](c)
-    val body = h.readBody
-    c.universe.reify {
+  def reader[A: c.WeakTypeTag, Opts: c.WeakTypeTag](c: Context): c.Expr[BSONDocumentReader[A]] =
+    c.universe.reify(
       new BSONDocumentReader[A] {
-        def read(document: BSONDocument): A = body.splice
-      }
-    }
-  }
+        def read(document: BSONDocument): A =
+          Helper[A, Opts](c).readBody.splice
+      })
 
-  def writer[A: c.WeakTypeTag, Opts: c.WeakTypeTag](c: Context): c.Expr[BSONDocumentWriter[A]] = {
-    val h = Helper[A, Opts](c)
-    val body = h.writeBody
+  def writer[A: c.WeakTypeTag, Opts: c.WeakTypeTag](c: Context): c.Expr[BSONDocumentWriter[A]] =
     c.universe.reify(
       new BSONDocumentWriter[A] {
-        def write(document: A): BSONDocument = body.splice
+        def write(document: A): BSONDocument =
+          Helper[A, Opts](c).writeBody.splice
       })
-  }
 
   def handler[A: c.WeakTypeTag, Opts: c.WeakTypeTag](c: Context): c.Expr[BSONDocumentReader[A] with BSONDocumentWriter[A] with BSONHandler[BSONDocument, A]] = {
-    val h = Helper[A, Opts](c)
-    val r = h.readBody
-    val w = h.writeBody
+    val helper = Helper[A, Opts](c)
     c.universe.reify(
       new BSONDocumentReader[A] with BSONDocumentWriter[A] with BSONHandler[BSONDocument, A] {
-        def read(document: BSONDocument): A = r.splice
+        def read(document: BSONDocument): A = helper.readBody.splice
 
-        def write(document: A): BSONDocument = w.splice
+        def write(document: A): BSONDocument = helper.writeBody.splice
       })
   }
 
@@ -49,9 +41,10 @@ private object MacroImpl {
   }
 
   private abstract class Helper[C <: Context, A](val c: C) {
+    import c.universe._
+
     protected def A: c.Type
     protected def Opts: c.Type
-    import c.universe._
 
     lazy val readBody: c.Expr[A] = {
       val writer = unionTypes map { types =>
@@ -62,7 +55,7 @@ private object MacroImpl {
             Literal(Constant(typ.typeSymbol.fullName)) //todo
 
           val body = readBodyFromImplicit(typ)
-          CaseDef(pattern, body)
+          cq"$pattern => $body"
         }
         val className = c.parse("""document.getAs[String]("className").get""")
         Match(className, cases)
@@ -79,11 +72,11 @@ private object MacroImpl {
     lazy val writeBody: c.Expr[BSONDocument] = {
       val writer = unionTypes map { types =>
         val cases = types map { typ =>
-          val pattern = Bind(newTermName("document"), Typed(Ident(nme.WILDCARD), TypeTree(typ)))
+          val pattern = Bind(TermName("document"), Typed(Ident(termNames.WILDCARD), TypeTree(typ)))
           val body = writeBodyFromImplicit(typ)
-          CaseDef(pattern, body)
+          cq"$pattern => $body"
         }
-        Match(Ident("document"), cases)
+        Match(Ident(TermName("document")), cases)
       } getOrElse writeBodyConstruct(A)
 
       val result = c.Expr[BSONDocument](writer)
@@ -97,7 +90,7 @@ private object MacroImpl {
     private def readBodyFromImplicit(A: c.Type) = {
       val reader = c.inferImplicitValue(appliedType(readerType, List(A)))
       if (!reader.isEmpty)
-        Apply(Select(reader, "read"), List(Ident("document")))
+        Apply(Select(reader, TermName("read")), List(Ident(TermName("document"))))
       else
         readBodyConstruct(A)
     }
@@ -115,14 +108,14 @@ private object MacroImpl {
         case TypeRef(_, sym, _) => sym
         case _                  => c.abort(c.enclosingPosition, s"Something weird is going on with '$A'. Should be a singleton but can't parse it")
       }
-      val name = stringToTermName(sym.name.toString) //this is ugly but quite stable compared to other attempts
+      val name = TermName(sym.name.toString) //this is ugly but quite stable compared to other attempts
       Ident(name)
     }
 
     private def readBodyConstructClass(implicit A: c.Type) = {
       val (constructor, _) = matchingApplyUnapply
 
-      val values = constructor.paramss.head map {
+      val values = constructor.paramLists.head map {
         param =>
           val sig = param.typeSignature
           val optTyp = optionTypeParameter(sig)
@@ -131,133 +124,124 @@ private object MacroImpl {
           if (optTyp.isDefined) {
             Apply(
               TypeApply(
-                Select(Ident("document"), "getAs"),
+                Select(Ident(TermName("document")), TermName("getAs")),
                 List(TypeTree(typ))),
               List(Literal(Constant(paramName(param)))))
           } else {
             val getter = Apply(
               TypeApply(
-                Select(Ident("document"), "getAsTry"),
+                Select(Ident(TermName("document")), TermName("getAsTry")),
                 List(TypeTree(typ))),
               List(Literal(Constant(paramName(param)))))
-            Select(getter, "get")
+            Select(getter, TermName("get"))
           }
 
       }
 
-      val constructorTree = Select(Ident(companion.name.toString), "apply")
+      val constructorTree = Select(Ident(companion.name), TermName("apply"))
       Apply(constructorTree, values)
     }
 
     private def writeBodyFromImplicit(A: c.Type) = {
       val writer = c.inferImplicitValue(appliedType(writerType, List(A)))
       if (!writer.isEmpty) {
-        val doc = Apply(Select(writer, "write"), List(Ident("document")))
+        val doc = Apply(Select(writer, TermName("write")),
+          List(Ident(TermName("document"))))
+
         classNameTree(A) map { className =>
           val nameE = c.Expr[(String, BSONString)](className)
           val docE = c.Expr[BSONDocument](doc)
+
           reify {
-            docE.splice ++ BSONDocument(Seq((nameE.splice)))
+            docE.splice ++ BSONDocument(Seq(nameE.splice))
           }.tree
         } getOrElse doc
-      } else
-        writeBodyConstruct(A)
+      } else writeBodyConstruct(A)
     }
 
     private def writeBodyConstruct(A: c.Type): c.Tree = {
-      if (isSingleton(A))
-        writeBodyConstructSingleton(A)
-      else
-        writeBodyConstructClass(A)
+      if (isSingleton(A)) writeBodyConstructSingleton(A)
+      else writeBodyConstructClass(A)
     }
 
-    private def writeBodyConstructSingleton(A: c.Type): c.Tree = {
-      val expr = classNameTree(A) map { className =>
+    private def writeBodyConstructSingleton(A: c.Type): c.Tree = (
+      classNameTree(A) map { className =>
         val nameE = c.Expr[(String, BSONString)](className)
         reify { BSONDocument(Seq((nameE.splice))) }
       } getOrElse reify { BSONDocument.empty }
-      expr.tree
-    }
+      ).tree
 
     private def writeBodyConstructClass(A: c.Type): c.Tree = {
       val (constructor, deconstructor) = matchingApplyUnapply(A)
       val types = unapplyReturnTypes(deconstructor)
-      val constructorParams = constructor.paramss.head
+      val constructorParams = constructor.paramLists.head
 
-      val tuple = Ident(newTermName("tuple"))
+      val tuple = Ident(TermName("tuple"))
       val (optional, required) = constructorParams.zipWithIndex.filterNot(p => ignoreField(p._1)) zip types partition (t => isOptionalType(t._2))
       val values = required map {
-        case ((param, i), typ) => {
+        case ((param, i), typ) =>
           val neededType = appliedType(writerType, List(typ))
           val writer = c.inferImplicitValue(neededType)
           if (writer.isEmpty) c.abort(c.enclosingPosition, s"Implicit $typ for '$param' not found")
-          val tuple_i = if (types.length == 1) tuple else Select(tuple, "_" + (i + 1))
-          val bs_value = c.Expr[BSONValue](Apply(Select(writer, "write"), List(tuple_i)))
-          val name = c.literal(paramName(param))
-          reify(
-            (name.splice, bs_value.splice): (String, BSONValue)).tree
-        }
+          val tuple_i = if (types.length == 1) tuple else Select(tuple, TermName("_" + (i + 1)))
+          val bs_value = c.Expr[BSONValue](Apply(Select(writer, TermName("write")), List(tuple_i)))
+          val name = c.Expr[String](q"${paramName(param)}")
+          reify((name.splice, bs_value.splice): (String, BSONValue)).tree
       }
 
       val appends = optional map {
-        case ((param, i), optType) => {
+        case ((param, i), optType) =>
           val typ = optionTypeParameter(optType).get
           val neededType = appliedType(writerType, List(typ))
           val writer = c.inferImplicitValue(neededType)
           if (writer.isEmpty) c.abort(c.enclosingPosition, s"Implicit $typ for '$param' not found")
-          val tuple_i = if (types.length == 1) tuple else Select(tuple, "_" + (i + 1))
-          val buf = Ident("buf")
-          val bs_value = c.Expr[BSONValue](Apply(Select(writer, "write"), List(Select(tuple_i, "get"))))
-          val name = c.literal(paramName(param))
+          val tuple_i = if (types.length == 1) tuple else Select(tuple, TermName("_" + (i + 1)))
+          val bs_value = c.Expr[BSONValue](Apply(Select(writer, TermName("write")), List(Select(tuple_i, TermName("get")))))
+          val name = c.Expr[String](q"${paramName(param)}")
           If(
-            Select(tuple_i, "isDefined"),
-            Apply(Select(Ident("buf"), "$plus$colon$eq"), List(reify((name.splice, bs_value.splice)).tree)),
+            Select(tuple_i, TermName("isDefined")),
+            Apply(Select(Ident(TermName("buf")), TermName("$plus$colon$eq")), List(reify((name.splice, bs_value.splice)).tree)),
             EmptyTree)
-        }
       }
 
       val mkBSONdoc = Apply(bsonDocPath, values ++ classNameTree(A))
 
-      val withAppends = List(
-        ValDef(Modifiers(), newTermName("bson"), TypeTree(), mkBSONdoc),
-        c.parse("var buf = scala.collection.immutable.Stream[(String,reactivemongo.bson.BSONValue)]()")) ++ appends :+ c.parse("bson.add(reactivemongo.bson.BSONDocument(buf))")
+      val writer = {
+        if (optional.isEmpty) List(mkBSONdoc)
+        else List(
+          ValDef(Modifiers(), TermName("bson"), TypeTree(), mkBSONdoc),
+          c.parse("var buf = scala.collection.immutable.Stream[(String,reactivemongo.bson.BSONValue)]()")) ++ appends :+ c.parse("bson.add(reactivemongo.bson.BSONDocument(buf))")
+      }
 
-      val writer = if (optional.length == 0) List(mkBSONdoc) else withAppends
-
-      val unapplyTree = Select(Ident(companion(A).name.toString), "unapply")
-      val document = Ident(newTermName("document"))
-      val invokeUnapply = Select(Apply(unapplyTree, List(document)), "get")
-      val tupleDef = ValDef(Modifiers(), newTermName("tuple"), TypeTree(), invokeUnapply)
+      val unapplyTree = Select(Ident(companion(A).name), TermName("unapply"))
+      val invokeUnapply = Select(Apply(unapplyTree, List(Ident(TermName("document")))), TermName("get"))
+      val tupleDef = ValDef(Modifiers(), TermName("tuple"), TypeTree(), invokeUnapply)
 
       if (values.length + appends.length > 0) {
-        Block((tupleDef :: writer): _*)
-      } else {
-        writer.head
-      }
+        val trees = tupleDef :: writer
+        q"{..$trees}"
+      } else writer.head
     }
 
     private def classNameTree(A: c.Type) = {
-      val className = if (hasOption[Macros.Options.SaveClassName]) Some {
+      if (hasOption[Macros.Options.SaveClassName]) Some {
         val name = if (hasOption[Macros.Options.SaveSimpleName])
-          c.literal(A.typeSymbol.name.decodedName.toString)
+          c.Expr[String](q"${A.typeSymbol.name.decodedName.toString}")
         else
-          c.literal(A.typeSymbol.fullName)
+          c.Expr[String](q"${A.typeSymbol.fullName}")
 
-        reify {
-          ("className", BSONStringHandler.write(name.splice))
-        }.tree
+        reify(("className", BSONStringHandler.write(name.splice))).tree
       }
       else None
-      className
     }
 
-    private lazy val unionTypes: Option[List[c.Type]] = {
+    private lazy val unionTypes: Option[List[c.Type]] =
       parseUnionTypes orElse parseAllImplementationTypes
-    }
 
     private def parseUnionTypes: Option[List[c.Type]] = {
       val unionOption = c.typeOf[Macros.Options.UnionType[_]]
       val union = c.typeOf[Macros.Options.\/[_, _]]
+
       def parseUnionTree(tree: Type): List[Type] = {
         if (tree <:< union) {
           tree match {
@@ -279,12 +263,9 @@ private object MacroImpl {
     }
 
     private def parseAllImplementationTypes: Option[List[Type]] = {
-      val allOption = typeOf[Macros.Options.AllImplementations]
-      if (Opts <:< allOption) {
+      if (Opts <:< typeOf[Macros.Options.AllImplementations]) {
         Some(allImplementations(A).toList)
-      } else {
-        None
-      }
+      } else None
     }
 
     private def hasOption[O: c.TypeTag]: Boolean = Opts <:< typeOf[O]
@@ -315,18 +296,16 @@ private object MacroImpl {
       else None
     }
 
-    private def isOptionalType(implicit A: c.Type): Boolean = {
-      c.typeOf[Option[_]].typeConstructor == A.typeConstructor
-    }
+    private def isOptionalType(implicit A: c.Type): Boolean =
+      (c.typeOf[Option[_]].typeConstructor == A.typeConstructor)
 
-    private def bsonDocPath: c.universe.Select = {
-      Select(Select(Ident(newTermName("reactivemongo")), "bson"), "BSONDocument")
-    }
+    private def bsonDocPath: c.universe.Select = Select(Select(Ident(
+      TermName("reactivemongo")), TermName("bson")), TermName("BSONDocument"))
 
     private def paramName(param: c.Symbol): String = {
       param.annotations.collect {
-        case ann if ann.tpe =:= typeOf[Key] =>
-          ann.scalaArgs.collect {
+        case ann if ann.tree.tpe =:= typeOf[Key] =>
+          ann.tree.children.tail.collect {
             case l: Literal => l.value.value
           }.collect {
             case value: String => value
@@ -334,9 +313,9 @@ private object MacroImpl {
       }.flatten.headOption getOrElse param.name.toString
     }
 
-    private def ignoreField(param: c.Symbol): Boolean = {
-      param.annotations.exists(ann => ann.tpe =:= typeOf[Ignore] || ann.tpe =:= typeOf[transient])
-    }
+    private def ignoreField(param: c.Symbol): Boolean =
+      param.annotations.exists(ann =>
+        ann.tree.tpe =:= typeOf[Ignore] || ann.tree.tpe =:= typeOf[transient])
 
     private def allSubclasses(A: Symbol): Set[Symbol] = {
       val sub = A.asClass.knownDirectSubclasses
@@ -344,24 +323,21 @@ private object MacroImpl {
       subsub ++ sub + A
     }
 
-    private def allImplementations(A: Type) = {
-      val classes = allSubclasses(A.typeSymbol) map (_.asClass)
-      classes filterNot (_.isAbstractClass) map (_.toType)
-    }
+    private def allImplementations(A: Type) =
+      allSubclasses(A.typeSymbol).map(_.asClass).
+        filterNot(_.isAbstract).map(_.toType)
 
-    private def applyMethod(implicit A: c.Type): c.universe.Symbol = {
-      companion(A).typeSignature.declaration(stringToTermName("apply")) match {
+    private def applyMethod(implicit A: c.Type): c.universe.Symbol =
+      companion(A).typeSignature.decl(TermName("apply")) match {
         case NoSymbol => c.abort(c.enclosingPosition, s"No apply function found for $A")
         case s        => s
       }
-    }
 
-    private def unapplyMethod(implicit A: c.Type): c.universe.MethodSymbol = {
-      companion(A).typeSignature.declaration(stringToTermName("unapply")) match {
+    private def unapplyMethod(implicit A: c.Type): c.universe.MethodSymbol =
+      companion(A).typeSignature.decl(TermName("unapply")) match {
         case NoSymbol => c.abort(c.enclosingPosition, s"No unapply function found for $A")
         case s        => s.asMethod
       }
-    }
 
     private def matchingApplyUnapply(implicit A: c.Type): (c.universe.MethodSymbol, c.universe.MethodSymbol) = {
       val applySymbol = applyMethod(A)
@@ -370,7 +346,7 @@ private object MacroImpl {
       val alternatives = applySymbol.asTerm.alternatives map (_.asMethod)
       val u = unapplyReturnTypes(unapply)
       val applys = alternatives filter { alt =>
-        val sig = alt.paramss.head.map(_.typeSignature)
+        val sig = alt.paramLists.head.map(_.typeSignature)
         sig.size == u.size && sig.zip(u).forall {
           case (left, right) => left =:= right
         }
@@ -384,9 +360,11 @@ private object MacroImpl {
     type Writer[A] = BSONWriter[A, _ <: BSONValue]
 
     private def isSingleton(t: Type): Boolean = t <:< typeOf[Singleton]
+
     private def writerType: c.Type = typeOf[Writer[_]].typeConstructor
+
     private def readerType: c.Type = typeOf[Reader[_]].typeConstructor
 
-    private def companion(implicit A: c.Type): c.Symbol = A.typeSymbol.companionSymbol
+    private def companion(implicit A: c.Type): c.Symbol = A.typeSymbol.companion
   }
 }


### PR DESCRIPTION
I needed to customize the handler macro for a personal project, so I thought it might be nice to remove deprecated API usage since I'm already there (even though I'm not much of a macro magician).