### PR TITLE
killcursors: found 0 of 1 when read preferrence = secondaryPreferred

### DIFF
--- a/project/ReactiveMongo.scala
+++ b/project/ReactiveMongo.scala
@@ -3,7 +3,7 @@ import sbt.Keys._
 import scala.language.postfixOps
 
 object BuildSettings {
-  val buildVersion = "0.12.0-SNAPSHOT"
+  val buildVersion = "0.11.9"
 
   val filter = { (ms: Seq[(File, String)]) =>
     ms filter {


### PR DESCRIPTION
- reactivemongo 0.11.9
- mongodb 3.2.0
- Ubuntu Server 15.10
- Java HotSpot(TM) 64-Bit Server VM (build 25.66-b17, mixed mode)
- scala 2.11.7
- playframework 2.4.6

I have a replica deployment with a master, two secondaries (one of which is hidden), and an arbiter.

Today I enabled secondary reads for some requests: https://github.com/ornicar/lila/commit/9bfcc02ceaf95411bf69aae26d7427ff6209a9b8#diff-d89f3da96aa10f0402ced61e77dc41f3R66

The reads are indeed performed on the secondary instead of the primary, and all is fine. Except... The mongodb primary log now shows these lines:

```
2016-03-03T07:38:02.140+0100 I COMMAND  [conn63] killcursors: found 0 of 1 
2016-03-03T07:38:02.206+0100 I COMMAND  [conn64] killcursors: found 0 of 1
2016-03-03T07:38:02.491+0100 I COMMAND  [conn57] killcursors: found 0 of 1
2016-03-03T07:38:02.694+0100 I COMMAND  [conn63] killcursors: found 0 of 1
2016-03-03T07:38:03.092+0100 I COMMAND  [conn62] killcursors: found 0 of 1
... many more
```

This began to happen when I deployed the secondary read preference.

The secondary logs are fine.

Since the reads are working, this might only be log pollution, but it still looks quite bad and I figured it might come from the driver. Sorry in advance if it does not.

Thank you for reactivemongo, cheers!