### PR TITLE
Adding parentheses to side-effecting function BSONObjectID.generate()

### DIFF
--- a/bson/src/main/scala/bson.scala
+++ b/bson/src/main/scala/bson.scala
@@ -49,7 +49,7 @@ object `package` extends DefaultBSONHandlers {
   def array(values: Producer[BSONValue]*) = BSONArray(values: _*)
 
   /** Returns a newly generated object ID. */
-  def generateId = BSONObjectID.generate
+  def generateId = BSONObjectID.generate()
 }
 
 sealed trait Producer[T] {

--- a/bson/src/main/scala/types.scala
+++ b/bson/src/main/scala/types.scala
@@ -438,7 +438,7 @@ object BSONObjectID {
    * The returned BSONObjectID contains a timestamp set to the current time (in seconds),
    * with the `machine identifier`, `thread identifier` and `increment` properly set.
    */
-  def generate: BSONObjectID = fromTime(System.currentTimeMillis, false)
+  def generate(): BSONObjectID = fromTime(System.currentTimeMillis, false)
 
   /**
    * Generates a new BSON ObjectID from the given timestamp in milliseconds.

--- a/bson/src/test/scala/Types.scala
+++ b/bson/src/test/scala/Types.scala
@@ -30,7 +30,7 @@ object Types extends Specification {
        *   ip -6 addr add 2001:DB8::`printf %04x $i`/128 dev tun$i
        * done
        */
-      BSONObjectID.generate must beAnInstanceOf[BSONObjectID]
+      BSONObjectID.generate() must beAnInstanceOf[BSONObjectID]
     }
   }
 

--- a/driver/src/main/scala/api/gridfs.scala
+++ b/driver/src/main/scala/api/gridfs.scala
@@ -134,7 +134,7 @@ class DefaultFileToSave(
   val contentType: Option[String] = None,
   val uploadDate: Option[Long] = None,
   val metadata: BSONDocument = BSONDocument.empty,
-  val id: BSONValue = BSONObjectID.generate)
+  val id: BSONValue = BSONObjectID.generate())
     extends FileToSave[BSONSerializationPack.type, BSONValue] with Equals {
 
   val pack = BSONSerializationPack
@@ -180,7 +180,7 @@ object DefaultFileToSave {
                contentType: Option[String] = None,
                uploadDate: Option[Long] = None,
                metadata: BSONDocument = BSONDocument.empty,
-               id: BSONValue = BSONObjectID.generate)(implicit naming: FileName[N]): DefaultFileToSave = new DefaultFileToSave(naming(filename), contentType, uploadDate, metadata, id)
+               id: BSONValue = BSONObjectID.generate())(implicit naming: FileName[N]): DefaultFileToSave = new DefaultFileToSave(naming(filename), contentType, uploadDate, metadata, id)
 
 }
 

--- a/driver/src/test/scala/BsonSpec.scala
+++ b/driver/src/test/scala/BsonSpec.scala
@@ -127,20 +127,20 @@ object BSONObjectIDSpec extends Specification {
   "BSONObjectID" should {
 
     "equal when created with string" in {
-      val objectID = BSONObjectID.generate
+      val objectID = BSONObjectID.generate()
       val sameObjectID = BSONObjectID(objectID.stringify)
       objectID.valueAsArray must equalTo(sameObjectID.valueAsArray)
     }
 
     "equal another instance of BSONObjectID with the same value" in {
-      val objectID = BSONObjectID.generate
+      val objectID = BSONObjectID.generate()
       val sameObjectID = BSONObjectID(objectID.stringify)
       objectID must equalTo(sameObjectID)
     }
 
     "not equal another newly generated instance of BSONObjectID" in {
-      val objectID = BSONObjectID.generate
-      val nextObjectID = BSONObjectID(BSONObjectID.generate.stringify)
+      val objectID = BSONObjectID.generate()
+      val nextObjectID = BSONObjectID(BSONObjectID.generate().stringify)
       objectID must not equalTo (nextObjectID)
     }
 
@@ -156,7 +156,7 @@ object BSONObjectIDSpec extends Specification {
     }
 
     "bytes generated equal bytes converted from string" in {
-      val objectID = BSONObjectID.generate
+      val objectID = BSONObjectID.generate()
       val bytes = Converters.str2Hex(objectID.stringify)
       objectID.valueAsArray must equalTo(bytes)
     }

--- a/macros/src/test/scala/macrospec.scala
+++ b/macros/src/test/scala/macrospec.scala
@@ -21,11 +21,11 @@ class Macros extends Specification {
   case class Single(value: String)
   case class OptionalSingle(value: Option[String])
   case class SingleTuple(value: (String, String))
-  case class User(_id: BSONObjectID = BSONObjectID.generate, name: String)
+  case class User(_id: BSONObjectID = BSONObjectID.generate(), name: String)
   case class WordLover(name: String, words: Seq[String])
   case class Empty()
   object EmptyObject
-  case class RenamedId(@Key("_id") myID: BSONObjectID = BSONObjectID.generate, @CustomAnnotation value: String)
+  case class RenamedId(@Key("_id") myID: BSONObjectID = BSONObjectID.generate(), @CustomAnnotation value: String)
 
   object Nest {
     case class Nested(name: String)


### PR DESCRIPTION
A generator is per-definition not purely functional; the lack of
parentheses was misleading. Let's follow [Scala's Style Guide](http://docs.scala-lang.org/style/method-invocation.html#arity0):
"Scala allows the omission of parentheses on methods of arity-0 (no arguments).
However, this syntax should only be used when the method in question has no
side-effects (purely-functional)[...] Religiously observing this convention
will dramatically improve code readability and will make it much easier to
understand at a glance the most basic operation of any given method. Resist the
urge to omit parentheses simply to save two characters!"