### PR TITLE
Support taggable read preference on shard router

### DIFF
--- a/driver/src/test/scala/AggregationSpec.scala
+++ b/driver/src/test/scala/AggregationSpec.scala
@@ -36,7 +36,7 @@ object AggregationSpec extends org.specs2.mutable.Specification {
     ZipCode("10280", "NEW YORK", "NY", 19746227L,
       Location(-74.016323, 40.710537)),
     ZipCode("72000", "LE MANS", "FR", 148169L, Location(48.0077, 0.1984)),
-    ZipCode("JP-13", "TOKYO", "JP", 13185502L,
+    ZipCode("JP 13", "TOKYO", "JP", 13185502L,
       Location(35.683333, 139.683333)),
     ZipCode("AO", "AOGASHIMA", "JP", 200L, Location(32.457, 139.767)))
 
@@ -141,7 +141,7 @@ object AggregationSpec extends org.specs2.mutable.Specification {
 
           val pipeline = List(Sort(MetadataSort("score", TextScore)))
           val expected = List(BSONDocument(
-            "_id" -> "JP-13",
+            "_id" -> "JP 13",
             "city" -> "TOKYO",
             "state" -> "JP",
             "population" -> 13185502L,
@@ -158,7 +158,10 @@ object AggregationSpec extends org.specs2.mutable.Specification {
                 "lat" -> 139.767D)))
 
           coll.aggregate1[BSONDocument](firstOp, pipeline, Cursor(1)).
-            flatMap(_.collect[List](4)) must beEqualTo(expected).
+            flatMap(_.collect[List](4)).andThen {
+              case scala.util.Success(res) =>
+                println(s"========> [[[[ ${res.map(BSONDocument.pretty)} ]]]]")
+            } must beEqualTo(expected).
             await(1, timeout)
 
         }

--- a/project/ReactiveMongo.scala
+++ b/project/ReactiveMongo.scala
@@ -168,7 +168,7 @@ object Dependencies {
 
   val playIteratees = "com.typesafe.play" %% "play-iteratees" % "2.3.10"
 
-  val specs = "org.specs2" %% "specs2-core" % "3.7.2" % Test
+  val specs = "org.specs2" %% "specs2-core" % "3.8.2" % Test
 
   val slf4jVer = "1.7.12"
   val log4jVer = "2.5"
@@ -254,11 +254,77 @@ object ReactiveMongoBuild extends Build {
         @inline def mmp(s: String) = x[MissingMethodProblem](s)
         @inline def imt(s: String) = x[IncompatibleMethTypeProblem](s)
         @inline def fmp(s: String) = x[FinalMethodProblem](s)
+        @inline def fcp(s: String) = x[FinalClassProblem](s)
         @inline def irt(s: String) = x[IncompatibleResultTypeProblem](s)
         @inline def mtp(s: String) = x[MissingTypesProblem](s)
         @inline def mcp(s: String) = x[MissingClassProblem](s)
 
         Seq(
+          fcp("reactivemongo.core.nodeset.ChannelFactory"),
+          mcp("reactivemongo.core.actors.RefreshAllNodes"),
+          mcp("reactivemongo.core.actors.RefreshAllNodes$"),
+          mmp("reactivemongo.core.actors.MongoDBSystem.DefaultConnectionRetryInterval"),
+          imt("reactivemongo.core.netty.ChannelBufferReadableBuffer.apply"),
+          irt("reactivemongo.core.netty.ChannelBufferReadableBuffer.buffer"),
+          imt("reactivemongo.core.netty.ChannelBufferReadableBuffer.this"),
+          irt("reactivemongo.core.netty.ChannelBufferWritableBuffer.buffer"),
+          imt(
+            "reactivemongo.core.netty.ChannelBufferWritableBuffer.writeBytes"),
+          imt("reactivemongo.core.netty.ChannelBufferWritableBuffer.this"),
+          irt("reactivemongo.core.netty.BufferSequence.merged"),
+          imt("reactivemongo.core.netty.BufferSequence.this"),
+          imt("reactivemongo.core.netty.BufferSequence.apply"),
+          imt("reactivemongo.core.protocol.package.RichBuffer"),
+          imt(
+            "reactivemongo.core.protocol.BufferAccessors.writeTupleToBuffer2"),
+          imt(
+            "reactivemongo.core.protocol.BufferAccessors.writeTupleToBuffer4"),
+          imt(
+            "reactivemongo.core.protocol.BufferAccessors.writeTupleToBuffer3"),
+          mtp("reactivemongo.core.protocol.MongoHandler"),
+          imt("reactivemongo.core.protocol.MongoHandler.exceptionCaught"),
+          imt("reactivemongo.core.protocol.MongoHandler.channelConnected"),
+          imt("reactivemongo.core.protocol.MongoHandler.writeComplete"),
+          imt("reactivemongo.core.protocol.MongoHandler.log"),
+          imt("reactivemongo.core.protocol.MongoHandler.writeRequested"),
+          imt("reactivemongo.core.protocol.MongoHandler.messageReceived"),
+          imt("reactivemongo.core.protocol.MongoHandler.channelClosed"),
+          imt("reactivemongo.core.protocol.MongoHandler.channelDisconnected"),
+          mtp("reactivemongo.core.protocol.ResponseDecoder"),
+          imt("reactivemongo.core.protocol.ResponseDecoder.decode"),
+          mtp("reactivemongo.core.protocol.ResponseFrameDecoder"),
+          imt("reactivemongo.core.protocol.ResponseFrameDecoder.decode"),
+          imt("reactivemongo.core.protocol.BufferAccessors#BufferInteroperable.apply"),
+          mtp("reactivemongo.core.protocol.RequestEncoder"),
+          imt("reactivemongo.core.protocol.RequestEncoder.encode"),
+          mmp("reactivemongo.core.protocol.ChannelBufferReadable.apply"),
+          imt("reactivemongo.core.protocol.ChannelBufferReadable.readFrom"),
+          imt("reactivemongo.core.protocol.MessageHeader.readFrom"),
+          imt("reactivemongo.core.protocol.MessageHeader.apply"),
+          imt("reactivemongo.core.protocol.Response.copy"),
+          irt("reactivemongo.core.protocol.Response.documents"),
+          imt("reactivemongo.core.protocol.Response.this"),
+          imt("reactivemongo.core.protocol.ReplyDocumentIterator.apply"),
+          imt("reactivemongo.core.protocol.Response.apply"),
+          irt("reactivemongo.core.protocol.package#RichBuffer.writeString"),
+          irt("reactivemongo.core.protocol.package#RichBuffer.buffer"),
+          irt("reactivemongo.core.protocol.package#RichBuffer.writeCString"),
+          imt("reactivemongo.core.protocol.package#RichBuffer.this"),
+          imt("reactivemongo.core.protocol.Reply.readFrom"),
+          imt("reactivemongo.core.protocol.Reply.apply"),
+          imt("reactivemongo.core.nodeset.Connection.apply"),
+          imt("reactivemongo.core.nodeset.Connection.copy"),
+          irt("reactivemongo.core.nodeset.Connection.send"),
+          irt("reactivemongo.core.nodeset.Connection.channel"),
+          imt("reactivemongo.core.nodeset.Connection.this"),
+          irt("reactivemongo.core.nodeset.ChannelFactory.channelFactory"),
+          irt("reactivemongo.core.nodeset.ChannelFactory.create"),
+          mcp("reactivemongo.api.MongoDriver$CloseWithTimeout"),
+          mcp("reactivemongo.api.MongoDriver$CloseWithTimeout$"),
+          mtp("reactivemongo.api.FailoverStrategy$"),
+          irt(
+            "reactivemongo.api.collections.GenericCollection#BulkMaker.result"),
+          irt("reactivemongo.api.collections.GenericCollection#Mongo26WriteCommand.result"),
           x[IncompatibleTemplateDefProblem](
             "reactivemongo.core.actors.MongoDBSystem"),
           mcp("reactivemongo.core.actors.RequestIds"),


### PR DESCRIPTION
ReactiveMongo Version: 0.11.7
MongoDB version: 2.6.9, 3.x

Expected Behavior
1. Configure mongo driver to connect to mongos node
2. Configure ReadPreference.secondaryPreferred(BSONDocument("dc"->"sw"))
3. Execute find operation with the explain flag
4. The nodes with tag {"dc"->"sw"} should reply

Actual Behavior
4. mongos selects the nodes for processing request without the tag information. Just slaveOk flag is used.

From the source code of ReactiveMongo driver tags are used to create a partial function and perform the matching operation on client side. Matching logic is not performed when connection is established to mongos node (source code: nodeset.scala):
```
  private def pickFromGroupWithFilter(roundRobiner: RoundRobiner[Node, Vector], filter: Option[BSONDocument => Boolean], fallback: => Option[Node]) =
    filter.fold(fallback)(f =>
      roundRobiner.pickWithFilter(_.tags.fold(false)(f)))

  // http://docs.mongodb.org/manual/reference/read-preference/
  def pick(preference: ReadPreference): Option[(Node, Connection)] = {
    if (mongos.isDefined) {
      pickConnectionAndFlatten(mongos)
    } else preference match {
      case ReadPreference.Primary                    => pickConnectionAndFlatten(primary)
      case ReadPreference.PrimaryPreferred(filter)   => pickConnectionAndFlatten(primary.orElse(pickFromGroupWithFilter(secondaries, filter, secondaries.pick)))
      case ReadPreference.Secondary(filter)          => pickConnectionAndFlatten(pickFromGroupWithFilter(secondaries, filter, secondaries.pick))
      case ReadPreference.SecondaryPreferred(filter) => pickConnectionAndFlatten(pickFromGroupWithFilter(secondaries, filter, secondaries.pick).orElse(primary))
      case ReadPreference.Nearest(filter)            => pickConnectionAndFlatten(pickFromGroupWithFilter(nearestGroup, filter, nearest))
    }
  }
```

In mongo-java driver read preference is a part of the wire protocol, so mongos is able to select the nodes based on the tags (source code: FindOperation.java):
```
private BsonDocument asDocument(final ConnectionDescription connectionDescription, final ReadPreference readPreference) {
    BsonDocument document = new BsonDocument();

    if (modifiers != null) {
        document.putAll(modifiers);
    }

    if (sort != null) {
        document.put("$orderby", sort);
    }

    if (maxTimeMS > 0) {
        document.put("$maxTimeMS", new BsonInt64(maxTimeMS));
    }

    if (connectionDescription.getServerType() == SHARD_ROUTER && !readPreference.equals(primary())) {
        document.put("$readPreference", readPreference.toDocument());
    }

    if (document.isEmpty()) {
        document = filter != null ? filter : new BsonDocument();
    } else if (filter != null) {
        document.put("$query", filter);
    } else if (!document.containsKey("$query")) {
        document.put("$query", new BsonDocument());
    }

    return document;
}
```

The tags from read preference are not propagated to the request
bsoncollection.scala
```
  def merge(readPreference: ReadPreference): BSONDocument = {
    // Primary and SecondaryPreferred are encoded as the slaveOk flag;
    // the others are encoded as $readPreference field.
    val readPreferenceDocument = readPreference match {
      case ReadPreference.Primary                    => None
      case ReadPreference.PrimaryPreferred(filter)   => Some(BSONDocument("mode" -> "primaryPreferred"))
      case ReadPreference.Secondary(filter)          => Some(BSONDocument("mode" -> "secondary"))
      case ReadPreference.SecondaryPreferred(filter) => None
      case ReadPreference.Nearest(filter)            => Some(BSONDocument("mode" -> "nearest"))
    }
    val optionalFields = List(
      sortOption.map { "$orderby" -> _ },
      hintOption.map { "$hint" -> _ },
      maxTimeMsOption.map { "$maxTimeMS" -> BSONLong(_) },
      commentString.map { "$comment" -> BSONString(_) },
      option(explainFlag, "$explain" -> BSONBoolean(true)),
      option(snapshotFlag, "$snapshot" -> BSONBoolean(true)),
      readPreferenceDocument.map { "$readPreference" -> _ }).flatten
    val query = queryOption.getOrElse(BSONDocument())
    if (optionalFields.isEmpty)
      query
    else
      BSONDocument(("$query" -> query) :: optionalFields)
  }
```