### PR TITLE
BsonDocument with binary is mutated on reads

### DIFF
--- a/bson/src/main/scala/handlers.scala
+++ b/bson/src/main/scala/handlers.scala
@@ -236,7 +236,7 @@ trait DefaultBSONHandlers {
   }
 
   implicit object BSONBinaryHandler extends BSONHandler[BSONBinary, Array[Byte]] {
-    def read(bin: BSONBinary) = bin.value.readArray(bin.value.size)
+    def read(bin: BSONBinary) = bin.value.duplicate().readArray(bin.value.size)
     def write(xs: Array[Byte]) = BSONBinary(xs, Subtype.GenericBinarySubtype)
   }
 

--- a/bson/src/test/scala/Handlers.scala
+++ b/bson/src/test/scala/Handlers.scala
@@ -50,9 +50,11 @@ class Handlers extends org.specs2.mutable.Specification {
 
     "be read as byte array" in {
       val bytes = Array[Byte](1, 3, 5, 7)
+      val bin = BSONBinary(
+        ArrayReadableBuffer(bytes), Subtype.GenericBinarySubtype)
 
-      BSONBinary(ArrayReadableBuffer(bytes), Subtype.GenericBinarySubtype).
-        as[Array[Byte]] must_== bytes
+      bin.as[Array[Byte]] aka "read #1" must_== bytes and (
+        bin.as[Array[Byte]] aka "read #2" must_== bytes)
     }
   }
 

--- a/driver/src/test/scala/FailoverSpec.scala
+++ b/driver/src/test/scala/FailoverSpec.scala
@@ -64,8 +64,8 @@ class FailoverSpec extends org.specs2.mutable.Specification {
       }.aka("duration") must beLike[Long] {
         case duration =>
           (duration must be_>=(1465655000000L)) and (
-            duration must be_<(1466500000000L))
-      }.await(1, 1466500000000L.milliseconds) and {
+            duration must be_<(1467000000000L))
+      }.await(1, 1467000000000L.milliseconds) and {
         con.askClose()(timeout) must not(throwA[Exception]).await(1, timeout)
       }
     }

--- a/driver/src/test/scala/admin.scala
+++ b/driver/src/test/scala/admin.scala
@@ -43,8 +43,8 @@ class ReplSetGetStatusSpec extends Specification {
       import bson.BSONReplSetGetStatusImplicits._
 
       // TODO: Setup a successful replica set
-      connection("admin").runCommand(
-        ReplSetGetStatus) must throwA[CommandError].await(1, timeout)
+      connection.database("admin").flatMap(_.runCommand(
+        ReplSetGetStatus)) must throwA[CommandError].await(1, timeout)
     }
   }
 }
@@ -82,7 +82,7 @@ class ResyncSpec extends Specification {
     import bson.BSONResyncImplicits._
 
     "be successful" in { implicit ee: EE =>
-      connection("admin").runCommand(Resync) must not(
+      connection.database("admin").flatMap(_.runCommand(Resync)) must not(
         throwA[CommandError]).await(1, timeout)
     }
   }
@@ -95,8 +95,8 @@ class ReplSetMaintenanceSpec extends Specification {
     import bson.BSONReplSetMaintenanceImplicits._
 
     "fail outside replicaSet" in { implicit ee: EE =>
-      connection("admin").runCommand(
-        ReplSetMaintenance(true)) must throwA[CommandError].
+      connection.database("admin").flatMap(_.runCommand(
+        ReplSetMaintenance(true))) must throwA[CommandError].
         await(1, timeout)
     }
   }


### PR DESCRIPTION
Scala version 2.11
ReactiveMongo version 0.11.13 (current)
MongoDB version - not relevant
OS - Windows 7
JDK - 1.8.0_92

Reading a binary element in a BSonDocument consumes the binary data and mutates the object. Reading elements of other types do not consume them so this is unexpected and undesired behavior, nor do I see this behavior documented. The following test should pass.

```scala
  test("bug report") {
    val dbObject = BSONDocument("d" -> Array[Byte](1, 2, 3))
    dbObject.getAs[Array[Byte]]("d").get.contains(1.toByte) shouldBe true  // passes
    dbObject.getAs[Array[Byte]]("d").get.contains(1.toByte) shouldBe true  // fails because d was consumed
  }
```

fails with
```
None.get
java.util.NoSuchElementException: None.get
	at scala.None$.get(Option.scala:347)
	at scala.None$.get(Option.scala:345)
	at BugTest$$anonfun$6.apply$mcV$sp(BugTest.scala:8)
```
