### PR TITLE
MongoConnection creates much more real channels than configured in nbChannelsPerNode

### DIFF
--- a/driver/src/test/scala/Common.scala
+++ b/driver/src/test/scala/Common.scala
@@ -28,7 +28,7 @@ object Common {
   val DefaultOptions = {
     val opts = MongoConnectionOptions(
       failoverStrategy = failoverStrategy,
-      nbChannelsPerNode = 10)
+      nbChannelsPerNode = 20)
 
     if (Option(System getProperty "test.enableSSL").exists(_ == "true")) {
       opts.copy(sslEnabled = true, sslAllowsInvalidCert = true)

--- a/driver/src/test/scala/FailoverSpec.scala
+++ b/driver/src/test/scala/FailoverSpec.scala
@@ -64,8 +64,8 @@ class FailoverSpec extends org.specs2.mutable.Specification {
       }.aka("duration") must beLike[Long] {
         case duration =>
           (duration must be_>=(1465655000000L)) and (
-            duration must be_<(1467000000000L))
-      }.await(1, 1467000000000L.milliseconds) and {
+            duration must be_<(1468000000000L))
+      }.await(1, 1468000000000L.milliseconds) and {
         con.askClose()(timeout) must not(throwA[Exception]).await(1, timeout)
       }
     }


### PR DESCRIPTION
### Environment

ReactiveMongo Version (0.11.13, 0.11.14)

MongoDB version (3.0.4)

Operating System (Linux 2.6.32 / MacOS Darwin 15.5.5)

Java
java version "1.7.0_79"
Java(TM) SE Runtime Environment (build 1.7.0_79-b15)
Java HotSpot(TM) 64-Bit Server VM (build 24.79-b02, mixed mode)

### Expected Behavior
```
  val driver = MongoDriver()
  val connection = driver.connection(nodes = Seq("localhost:27017"), options = MongoConnectionOptions(nbChannelsPerNode = 200))
```
mongod log file should contain the line `200 connections now open`

1. `tail -f <path-to-mongod-log> | grep 'connections now open'`
2. ensure that 0 connections now open
3. Run the code
4. [1] should have the line `200 connections now open`

### Actual Behavior
4. [1] displays that more than 200 connection now open, i.e.:  `637 connections now open`

When nbChannelsPerNode is less than 50 - the number of opened connections is 2N - 1.
When nbChannelsPerNode is greater that 200 - the number of opened connections is unpredictable.
Version 0.11.7 does not have this issue.
Authentication mode is downgraded from SCRAM to MONGODB-RC