### PR TITLE
Check macros with generic case class

### DIFF
--- a/driver/src/main/scala/api/collections/genericcollection.scala
+++ b/driver/src/main/scala/api/collections/genericcollection.scala
@@ -168,7 +168,7 @@ trait GenericCollection[P <: SerializationPack with Singleton] extends Collectio
    *
    * This method accepts any query and projection object, provided that there is an implicit `Writer[S]` typeclass for handling them in the scope.
    *
-   * Please take a look to the [[http://www.mongodb.org/display/DOCS/Querying mongodb documentation]] to know how querying works.
+   * Please take a look at the [[http://www.mongodb.org/display/DOCS/Querying mongodb documentation]] to know how querying works.
    *
    * @tparam S the type of the selector (the query). An implicit `Writer[S]` typeclass for handling it has to be in the scope.
    *
@@ -183,7 +183,7 @@ trait GenericCollection[P <: SerializationPack with Singleton] extends Collectio
    *
    * This method accepts any selector and projection object, provided that there is an implicit `Writer[S]` typeclass for handling them in the scope.
    *
-   * Please take a look to the [[http://www.mongodb.org/display/DOCS/Querying mongodb documentation]] to know how querying works.
+   * Please take a look at the [[http://www.mongodb.org/display/DOCS/Querying mongodb documentation]] to know how querying works.
    *
    * @tparam S the type of the selector (the query). An implicit `Writer[S]` typeclass for handling it has to be in the scope.
    * @tparam P the type of the projection object. An implicit `Writer[P]` typeclass for handling it has to be in the scope.
@@ -201,7 +201,7 @@ trait GenericCollection[P <: SerializationPack with Singleton] extends Collectio
    *
    * This method accepts any query or hint, the scope provides instances of appropriate typeclasses.
    *
-   * Please take a look to the [[http://www.mongodb.org/display/DOCS/Querying mongodb documentation]] to know how querying works.
+   * Please take a look at the [[http://www.mongodb.org/display/DOCS/Querying mongodb documentation]] to know how querying works.
    *
    * @tparam H the type of hint. An implicit `H => Hint` conversion has to be in the scope.
    *

--- a/driver/src/main/scala/api/cursor.scala
+++ b/driver/src/main/scala/api/cursor.scala
@@ -278,6 +278,9 @@ sealed trait CursorOps[T] { cursor: Cursor[T] =>
    * according the provided read for the element type `T`.
    */
   private[reactivemongo] def documentIterator(response: Response): Iterator[T]
+
+  /** Returns true if this cursor is tailable. */
+  def tailable: Boolean
 }
 
 object CursorOps {

--- a/macros/src/main/scala-2.10/MacroImpl.scala
+++ b/macros/src/main/scala-2.10/MacroImpl.scala
@@ -5,11 +5,6 @@ import reactivemongo.bson.Macros.Options.SaveSimpleName
 
 import scala.reflect.macros.Context
 
-/**
-  * User: andraz
-  * Date: 2/21/13
-  * Time: 6:51 PM
-  */
 private object MacroImpl {
   def reader[A: c.WeakTypeTag, Opts: c.WeakTypeTag](c: Context): c.Expr[BSONDocumentReader[A]] =
     c.universe.reify(
@@ -115,27 +110,31 @@ private object MacroImpl {
     private def readBodyConstructClass(implicit A: c.Type) = {
       val (constructor, _) = matchingApplyUnapply
 
-      val values = constructor.paramss.head map {
-        param =>
-          val sig = param.typeSignature
-          val optTyp = optionTypeParameter(sig)
-          val typ = optTyp getOrElse sig
+      val TypeRef(_, _, tpeArgs) = A
+      val boundTypes = constructor.typeParams.zip(tpeArgs).map {
+        case (sym, ty) => sym.fullName -> ty
+      }.toMap
 
-          if (optTyp.isDefined) {
-            Apply(
-              TypeApply(
-                Select(Ident("document"), "getAs"),
-                List(TypeTree(typ))),
-              List(Literal(Constant(paramName(param)))))
-          } else {
-            val getter = Apply(
-              TypeApply(
-                Select(Ident("document"), "getAsTry"),
-                List(TypeTree(typ))),
-              List(Literal(Constant(paramName(param)))))
-            Select(getter, "get")
-          }
+      val values = constructor.paramss.head.map { param =>
+        val t = param.typeSignature
+        val sig = boundTypes.lift(t.typeSymbol.fullName).getOrElse(t)
+        val optTyp = optionTypeParameter(sig)
+        val typ = optTyp getOrElse sig
 
+        if (optTyp.isDefined) {
+          Apply(
+            TypeApply(
+              Select(Ident("document"), "getAs"),
+              List(TypeTree(typ))),
+            List(Literal(Constant(paramName(param)))))
+        } else {
+          val getter = Apply(
+            TypeApply(
+              Select(Ident("document"), "getAsTry"),
+              List(TypeTree(typ))),
+            List(Literal(Constant(paramName(param)))))
+          Select(getter, "get")
+        }
       }
 
       val constructorTree = Select(Ident(companion.name.toString), "apply")
@@ -253,32 +252,32 @@ private object MacroImpl {
           lst.headOption
 
         case RefinedType(types, _) =>
-          types.filter(_ <:< unionOption).flatMap { case TypeRef(_, _, args) => args }.headOption
+          types.filter(_ <:< unionOption).flatMap {
+            case TypeRef(_, _, args) => args
+          }.headOption
 
         case _ => None
       }
       tree map { t => parseUnionTree(t) }
     }
 
-    private def parseAllImplementationTypes: Option[List[Type]] = {
+    private def parseAllImplementationTypes: Option[List[Type]] =
       if (Opts <:< typeOf[Macros.Options.AllImplementations]) {
-        Some(allImplementations(A).toList)
+        Some(allSubclasses(Set(A.typeSymbol)).toList)
       } else None
-    }
 
     private def hasOption[O: c.TypeTag]: Boolean = Opts <:< typeOf[O]
 
     private def unapplyReturnTypes(deconstructor: c.universe.MethodSymbol): List[c.Type] = {
       val opt = deconstructor.returnType match {
         case TypeRef(_, _, Nil) => Some(Nil)
-        case TypeRef(_, _, args) =>
-          args.head match {
-            case t @ TypeRef(_, _, Nil) => Some(List(t))
-            case typ @ TypeRef(_, t, args) =>
-              Some(
-                if (t.name.toString.matches("Tuple\\d\\d?")) args else List(typ))
-            case _ => None
-          }
+        case TypeRef(_, _, args) => args.head match {
+          case t @ TypeRef(_, _, Nil) => Some(List(t))
+          case typ @ TypeRef(_, t, args) =>
+            Some(
+              if (t.name.toString.matches("Tuple\\d\\d?")) args else List(typ))
+          case _ => None
+        }
         case _ => None
       }
       opt getOrElse c.abort(c.enclosingPosition, "something wrong with unapply type")
@@ -315,15 +314,28 @@ private object MacroImpl {
       param.annotations.exists(ann =>
         ann.tpe =:= typeOf[Ignore] || ann.tpe =:= typeOf[transient])
 
-    private def allSubclasses(A: Symbol): Set[Symbol] = {
-      val sub = A.asClass.knownDirectSubclasses
-      val subsub = sub flatMap allSubclasses
-      subsub ++ sub + A
-    }
+    @annotation.tailrec
+    private def allSubclasses(parent: Set[Symbol], subclasses: Set[Type] = Set.empty): Set[Type] = parent.headOption match {
+      case Some(cls: ClassSymbol) => {
+        val subsub = cls.owner.typeSignature.declarations.collect {
+          case c: ClassSymbol if (
+            cls != c && c.selfType.baseClasses.contains(cls)
+          ) => c
 
-    private def allImplementations(A: Type) =
-      allSubclasses(A.typeSymbol).map(_.asClass).
-        filterNot(_.isAbstractClass).map(_.toType)
+          case o: ModuleSymbol if (o.companionSymbol == NoSymbol) => o
+        }
+
+        val isAbstract = cls.isTrait || cls.isAbstractClass
+        val up = if (!isAbstract) subclasses + cls.toType else subclasses
+
+        allSubclasses(parent.tail ++ subsub, up)
+      }
+
+      case Some(o: ModuleSymbol) =>
+        allSubclasses(parent.tail, subclasses + o.typeSignature)
+
+      case _ => subclasses
+    }
 
     private def applyMethod(implicit A: c.Type): c.universe.Symbol =
       companion(A).typeSignature.declaration(stringToTermName("apply")) match {
@@ -338,15 +350,31 @@ private object MacroImpl {
       }
 
     private def matchingApplyUnapply(implicit A: c.Type): (c.universe.MethodSymbol, c.universe.MethodSymbol) = {
+      import c.universe._
+
       val applySymbol = applyMethod(A)
       val unapply = unapplyMethod(A)
-
-      val alternatives = applySymbol.asTerm.alternatives map (_.asMethod)
+      val alternatives = applySymbol.asTerm.alternatives.map(_.asMethod)
       val u = unapplyReturnTypes(unapply)
-      val applys = alternatives filter { alt =>
-        val sig = alt.paramss.head.map(_.typeSignature)
-        sig.size == u.size && sig.zip(u).forall {
-          case (left, right) => left =:= right
+
+      val applys = alternatives.filter { alt =>
+        alt.paramss match {
+          case params :: Nil => {
+            val sig = params.map(_.typeSignature)
+
+            sig.size == u.size && sig.zip(u).forall {
+              case (TypeRef(NoPrefix, left, _), TypeRef(NoPrefix, right, _)) =>
+                left.fullName == right.fullName
+
+              case (left, right) => left =:= right
+            }
+          }
+
+          case _ => {
+            warn(c.enclosingPosition, s"""Constructor with multiple parameter lists is not supported: ${A.typeSymbol.name}${alt.typeSignature}""")
+
+            false
+          }
         }
       }
 
@@ -364,5 +392,8 @@ private object MacroImpl {
     private def readerType: c.Type = typeOf[Reader[_]].typeConstructor
 
     private def companion(implicit A: c.Type): c.Symbol = A.typeSymbol.companionSymbol
+
+    private def warn(pos: c.universe.Position, msg: String): Unit =
+      if (hasOption[Macros.Options.Verbose]) c.echo(pos, msg)
   }
 }

--- a/macros/src/main/scala-2.11/MacroImpl.scala
+++ b/macros/src/main/scala-2.11/MacroImpl.scala
@@ -3,13 +3,9 @@ package reactivemongo.bson
 import reactivemongo.bson.Macros.Annotations.{ Ignore, Key }
 import reactivemongo.bson.Macros.Options.SaveSimpleName
 
+import scala.collection.immutable.Set
 import scala.reflect.macros.whitebox.Context
 
-/**
-  * User: andraz
-  * Date: 2/21/13
-  * Time: 6:51 PM
-  */
 private object MacroImpl {
   def reader[A: c.WeakTypeTag, Opts: c.WeakTypeTag](c: Context): c.Expr[BSONDocumentReader[A]] =
     c.universe.reify(
@@ -27,10 +23,10 @@ private object MacroImpl {
 
   def handler[A: c.WeakTypeTag, Opts: c.WeakTypeTag](c: Context): c.Expr[BSONDocumentReader[A] with BSONDocumentWriter[A] with BSONHandler[BSONDocument, A]] = {
     val helper = Helper[A, Opts](c)
+
     c.universe.reify(
       new BSONDocumentReader[A] with BSONDocumentWriter[A] with BSONHandler[BSONDocument, A] {
         def read(document: BSONDocument): A = helper.readBody.splice
-
         def write(document: A): BSONDocument = helper.writeBody.splice
       })
   }
@@ -66,16 +62,18 @@ private object MacroImpl {
       if (hasOption[Macros.Options.Verbose]) {
         c.echo(c.enclosingPosition, show(result))
       }
+
       result
     }
 
     lazy val writeBody: c.Expr[BSONDocument] = {
-      val writer = unionTypes map { types =>
-        val cases = types map { typ =>
+      val writer = unionTypes.map { types =>
+        val cases = types.map { typ =>
           val pattern = Bind(TermName("document"), Typed(Ident(termNames.WILDCARD), TypeTree(typ)))
           val body = writeBodyFromImplicit(typ)
           cq"$pattern => $body"
         }
+
         Match(Ident(TermName("document")), cases)
       } getOrElse writeBodyConstruct(A)
 
@@ -84,6 +82,7 @@ private object MacroImpl {
       if (hasOption[Macros.Options.Verbose]) {
         c.echo(c.enclosingPosition, show(result))
       }
+
       result
     }
 
@@ -113,29 +112,35 @@ private object MacroImpl {
     }
 
     private def readBodyConstructClass(implicit A: c.Type) = {
+      import c.universe._
+
       val (constructor, _) = matchingApplyUnapply
 
-      val values = constructor.paramLists.head map {
-        param =>
-          val sig = param.typeSignature
-          val optTyp = optionTypeParameter(sig)
-          val typ = optTyp getOrElse sig
+      val TypeRef(_, _, tpeArgs) = A
+      val boundTypes = constructor.typeParams.zip(tpeArgs).map {
+        case (sym, ty) => sym.fullName -> ty
+      }.toMap
 
-          if (optTyp.isDefined) {
-            Apply(
-              TypeApply(
-                Select(Ident(TermName("document")), TermName("getAs")),
-                List(TypeTree(typ))),
-              List(Literal(Constant(paramName(param)))))
-          } else {
-            val getter = Apply(
-              TypeApply(
-                Select(Ident(TermName("document")), TermName("getAsTry")),
-                List(TypeTree(typ))),
-              List(Literal(Constant(paramName(param)))))
-            Select(getter, TermName("get"))
-          }
+      val values = constructor.paramLists.head.map { param =>
+        val t = param.typeSignature
+        val sig = boundTypes.lift(t.typeSymbol.fullName).getOrElse(t)
+        val optTyp = optionTypeParameter(sig)
+        val typ = optTyp getOrElse sig
 
+        if (optTyp.isDefined) {
+          Apply(
+            TypeApply(
+              Select(Ident(TermName("document")), TermName("getAs")),
+              List(TypeTree(typ))),
+            List(Literal(Constant(paramName(param)))))
+        } else {
+          val getter = Apply(
+            TypeApply(
+              Select(Ident(TermName("document")), TermName("getAsTry")),
+              List(TypeTree(typ))),
+            List(Literal(Constant(paramName(param)))))
+          Select(getter, TermName("get"))
+        }
       }
 
       val constructorTree = Select(Ident(companion.name), TermName("apply"))
@@ -242,6 +247,7 @@ private object MacroImpl {
       val unionOption = c.typeOf[Macros.Options.UnionType[_]]
       val union = c.typeOf[Macros.Options.\/[_, _]]
 
+      // TODO: tailrec
       def parseUnionTree(tree: Type): List[Type] = {
         if (tree <:< union) {
           tree match {
@@ -255,32 +261,33 @@ private object MacroImpl {
           lst.headOption
 
         case RefinedType(types, _) =>
-          types.filter(_ <:< unionOption).flatMap { case TypeRef(_, _, args) => args }.headOption
+          types.filter(_ <:< unionOption).flatMap {
+            case TypeRef(_, _, args) => args
+          }.headOption
 
         case _ => None
       }
-      tree map { t => parseUnionTree(t) }
+
+      tree.map { t => parseUnionTree(t) }
     }
 
-    private def parseAllImplementationTypes: Option[List[Type]] = {
+    private def parseAllImplementationTypes: Option[List[Type]] =
       if (Opts <:< typeOf[Macros.Options.AllImplementations]) {
-        Some(allImplementations(A).toList)
+        Some(allSubclasses(Set(A.typeSymbol.asClass)).toList)
       } else None
-    }
 
     private def hasOption[O: c.TypeTag]: Boolean = Opts <:< typeOf[O]
 
     private def unapplyReturnTypes(deconstructor: c.universe.MethodSymbol): List[c.Type] = {
       val opt = deconstructor.returnType match {
         case TypeRef(_, _, Nil) => Some(Nil)
-        case TypeRef(_, _, args) =>
-          args.head match {
-            case t @ TypeRef(_, _, Nil) => Some(List(t))
-            case typ @ TypeRef(_, t, args) =>
-              Some(
-                if (t.name.toString.matches("Tuple\\d\\d?")) args else List(typ))
-            case _ => None
-          }
+        case TypeRef(_, _, args) => args.head match {
+          case t @ TypeRef(_, _, Nil) => Some(List(t))
+          case typ @ TypeRef(_, t, args) =>
+            Some(
+              if (t.name.toString.matches("Tuple\\d\\d?")) args else List(typ))
+          case _ => None
+        }
         case _ => None
       }
       opt getOrElse c.abort(c.enclosingPosition, "something wrong with unapply type")
@@ -317,19 +324,33 @@ private object MacroImpl {
       param.annotations.exists(ann =>
         ann.tree.tpe =:= typeOf[Ignore] || ann.tree.tpe =:= typeOf[transient])
 
-    private def allSubclasses(A: Symbol): Set[Symbol] = {
-      val sub = A.asClass.knownDirectSubclasses
-      val subsub = sub flatMap allSubclasses
-      subsub ++ sub + A
-    }
+    @annotation.tailrec
+    private def allSubclasses(parent: Set[Symbol], subclasses: Set[Type] = Set.empty): Set[Type] = parent.headOption match {
+      case Some(cls: ClassSymbol) => {
+        val subsub = cls.owner.typeSignature.decls.collect {
+          case c: ClassSymbol if (
+            cls != c && c.selfType.baseClasses.contains(cls)
+          ) => c
 
-    private def allImplementations(A: Type) =
-      allSubclasses(A.typeSymbol).map(_.asClass).
-        filterNot(_.isAbstract).map(_.toType)
+          case o: ModuleSymbol if (o.companion == NoSymbol) => o
+        }
+
+        val up = if (!cls.isAbstract) subclasses + cls.toType else subclasses
+
+        allSubclasses(parent.tail ++ subsub, up)
+      }
+
+      case Some(o: ModuleSymbol) =>
+        allSubclasses(parent.tail, subclasses + o.typeSignature)
+
+      case _ => subclasses
+    }
 
     private def applyMethod(implicit A: c.Type): c.universe.Symbol =
       companion(A).typeSignature.decl(TermName("apply")) match {
-        case NoSymbol => c.abort(c.enclosingPosition, s"No apply function found for $A")
+        case NoSymbol => c.abort(c.enclosingPosition,
+          s"No apply function found for $A")
+
         case s        => s
       }
 
@@ -340,15 +361,31 @@ private object MacroImpl {
       }
 
     private def matchingApplyUnapply(implicit A: c.Type): (c.universe.MethodSymbol, c.universe.MethodSymbol) = {
+      import c.universe._
+
       val applySymbol = applyMethod(A)
       val unapply = unapplyMethod(A)
-
-      val alternatives = applySymbol.asTerm.alternatives map (_.asMethod)
+      val alternatives = applySymbol.asTerm.alternatives.map(_.asMethod)
       val u = unapplyReturnTypes(unapply)
-      val applys = alternatives filter { alt =>
-        val sig = alt.paramLists.head.map(_.typeSignature)
-        sig.size == u.size && sig.zip(u).forall {
-          case (left, right) => left =:= right
+
+      val applys = alternatives.filter { alt =>
+        alt.paramLists match {
+          case params :: Nil => {
+            val sig = params.map(_.typeSignature)
+
+            sig.size == u.size && (sig, u).zipped.forall {
+              case (TypeRef(NoPrefix, left, _), TypeRef(NoPrefix, right, _)) =>
+                left.fullName == right.fullName
+
+              case (left, right) => left =:= right
+            }
+          }
+
+          case _ => {
+            warn(c.enclosingPosition, s"""Constructor with multiple parameter lists is not supported: ${A.typeSymbol.name}${alt.typeSignature}""")
+
+            false
+          }
         }
       }
 
@@ -366,5 +403,8 @@ private object MacroImpl {
     private def readerType: c.Type = typeOf[Reader[_]].typeConstructor
 
     private def companion(implicit A: c.Type): c.Symbol = A.typeSymbol.companion
+
+    private def warn(pos: c.universe.Position, msg: => String): Unit =
+      if (hasOption[Macros.Options.Verbose]) c.echo(pos, msg)
   }
 }

--- a/macros/src/main/scala/Macros.scala
+++ b/macros/src/main/scala/Macros.scala
@@ -88,7 +88,10 @@ object Macros {
   /** Creates an instance of BSONReader and BSONWriter for case class A */
   def handler[A]: BSONDocumentReader[A] with BSONDocumentWriter[A] with BSONHandler[BSONDocument, A] = macro MacroImpl.handler[A, Options.Default]
 
-  /**Creates an instance of BSONReader and BSONWriter for case class A and takes additional options */
+  /**
+   * Creates an instance of BSONReader and BSONWriter for case class A,
+   * and takes additional options.
+   */
   def handlerOpts[A, Opts <: Options.Default]: BSONDocumentReader[A] with BSONDocumentWriter[A] with BSONHandler[BSONDocument, A] = macro MacroImpl.handler[A, Opts]
 
   /**

--- a/macros/src/test/scala/MacroSpec.scala
+++ b/macros/src/test/scala/MacroSpec.scala
@@ -1,115 +1,18 @@
-import reactivemongo.bson._
-import org.specs2.mutable._
+import reactivemongo.bson.{
+  BSON,
+  BSONDocument,
+  BSONDouble,
+  BSONReader,
+  BSONInteger,
+  BSONWriter,
+  Macros
+}
 import reactivemongo.bson.exceptions.DocumentKeyNotFound
-import reactivemongo.bson.Macros.Annotations.{ Key, Ignore }
 
-class Macros extends Specification {
-  type Handler[A] = BSONDocumentReader[A] with BSONDocumentWriter[A] with BSONHandler[BSONDocument, A]
+class MacroSpec extends org.specs2.mutable.Specification {
+  "Macros" title
 
-  def roundtrip[A](original: A, format: BSONReader[BSONDocument, A] with BSONWriter[A, BSONDocument]) = {
-    val serialized = format write original
-    val deserialized = format read serialized
-    original mustEqual deserialized
-  }
-
-  def roundtripImp[A](data: A)(implicit format: BSONReader[BSONDocument, A] with BSONWriter[A, BSONDocument]) = roundtrip(data, format)
-
-  case class Person(firstName: String, lastName: String)
-  case class Pet(name: String, owner: Person)
-  case class Primitives(dbl: Double, str: String, bl: Boolean, int: Int, long: Long)
-  case class Optional(name: String, value: Option[String])
-  case class Single(value: String)
-  case class OptionalSingle(value: Option[String])
-  case class SingleTuple(value: (String, String))
-  case class User(_id: BSONObjectID = BSONObjectID.generate(), name: String)
-  case class WordLover(name: String, words: Seq[String])
-  case class Empty()
-  object EmptyObject
-  case class RenamedId(@Key("_id") myID: BSONObjectID = BSONObjectID.generate(), @CustomAnnotation value: String)
-
-  object Nest {
-    case class Nested(name: String)
-  }
-
-  case class OverloadedApply(string: String)
-  object OverloadedApply {
-    def apply(n: Int) = { /* println(n) */ }
-
-    def apply(seq: Seq[String]): OverloadedApply = OverloadedApply(seq mkString " ")
-  }
-
-  object Union {
-    sealed trait UT
-    case class UA(n: Int) extends UT
-    case class UB(s: String) extends UT
-    case class UC(s: String) extends UT
-    case class UD(s: String) extends UT
-  }
-
-  trait NestModule {
-    case class Nested(name: String)
-    val format = Macros.handler[Nested]
-  }
-
-  object TreeModule {
-    //due to compiler limitations(read: only workaround I found), handlers must be defined here
-    //and explicit type annotations added to enable compiler to use implicit handlers recursively
-
-    sealed trait Tree
-    case class Node(left: Tree, right: Tree) extends Tree
-    case class Leaf(data: String) extends Tree
-
-    object Tree {
-      import Macros.Options._
-      implicit val bson: Handler[Tree] = Macros.handlerOpts[Tree, UnionType[Node \/ Leaf]]
-    }
-  }
-
-  object TreeCustom {
-    sealed trait Tree
-    case class Node(left: Tree, right: Tree) extends Tree
-    case class Leaf(data: String) extends Tree
-
-    object Leaf {
-      private val helper = Macros.handler[Leaf]
-      implicit val bson: Handler[Leaf] = new BSONDocumentReader[Leaf] with BSONDocumentWriter[Leaf] with BSONHandler[BSONDocument, Leaf] {
-        def write(t: Leaf): BSONDocument = helper.write(Leaf("hai"))
-        def read(bson: BSONDocument): Leaf = helper read bson
-      }
-    }
-
-    object Tree {
-      import Macros.Options._
-
-      implicit val bson: Handler[Tree] =
-        Macros.handlerOpts[Tree, UnionType[Node \/ Leaf]]
-      //Macros.handlerOpts[Tree, UnionType[Node \/ Leaf] with Verbose]
-    }
-  }
-
-  object IntListModule {
-    sealed trait IntList
-    case class Cons(head: Int, tail: IntList) extends IntList
-    case object Tail extends IntList
-
-    object IntList {
-      import Macros.Options.{ UnionType, \/ }
-
-      implicit val bson: Handler[IntList] = Macros.handlerOpts[IntList, UnionType[Cons \/ Tail.type]]
-    }
-  }
-
-  object InheritanceModule {
-    sealed trait T
-    case class A() extends T
-    case object B extends T
-    sealed trait TT extends T
-    case class C() extends TT
-  }
-
-  case class Pair(@Ignore left: String, right: String)
-
-  val pairHandler = Macros.handler[Pair]
+  import MacroTest._
 
   "Formatter" should {
     "handle primitives" in {
@@ -187,14 +90,17 @@ class Macros extends Specification {
       val person = Person("john", "doe")
       val format = Macros.handlerOpts[Person, Macros.Options.SaveClassName]
       val doc = format write person
-      doc.getAs[String]("className") mustEqual Some("Macros.Person")
-      roundtrip(person, format)
+
+      doc.getAs[String]("className") mustEqual Some("MacroTest.Person") and {
+        roundtrip(person, format)
+      }
     }
 
     "persist simple class name on demand" in {
       val person = Person("john", "doe")
       val format = Macros.handlerOpts[Person, Macros.Options.SaveSimpleName]
       val doc = format write person
+
       doc.getAs[String]("className") mustEqual Some("Person")
       roundtrip(person, format)
     }
@@ -211,11 +117,11 @@ class Macros extends Specification {
       println(BSONDocument pretty (format write b))
        */
 
-      format.write(a).getAs[String]("className") must beSome("Macros.Union.UA")
-      format.write(b).getAs[String]("className") must beSome("Macros.Union.UB")
-
-      roundtrip(a, format)
-      roundtrip(b, format)
+      format.write(a).getAs[String]("className").
+        aka("class #1") must beSome("MacroTest.Union.UA") and {
+          format.write(b).getAs[String]("className").
+            aka("class #2") must beSome("MacroTest.Union.UB")
+        } and roundtrip(a, format) and roundtrip(b, format)
     }
 
     "handle union types (ADT) with simple names" in {
@@ -233,8 +139,7 @@ class Macros extends Specification {
       format.write(a).getAs[String]("className") must beSome("UA")
       format.write(b).getAs[String]("className") must beSome("UB")
 
-      roundtrip(a, format)
-      roundtrip(b, format)
+      roundtrip(a, format) and roundtrip(b, format)
     }
 
     "handle recursive structure" in {
@@ -250,12 +155,14 @@ class Macros extends Specification {
       val serialized = BSON writeDocument tree
       val deserialized = BSON.readDocument[Tree](serialized)
       val expected = Node(Leaf("hai"), Node(Leaf("hai"), Leaf("hai")))
+
       deserialized mustEqual expected
     }
 
     "handle empty case classes" in {
       val empty = Empty()
       val format = Macros.handler[Empty]
+
       roundtrip(empty, format)
     }
 
@@ -266,6 +173,7 @@ class Macros extends Specification {
 
     "handle ADTs with objects" in {
       import IntListModule._
+
       roundtripImp[IntList](Tail)
       roundtripImp[IntList](Cons(1, Cons(2, Cons(3, Tail))))
     }
@@ -275,13 +183,13 @@ class Macros extends Specification {
       import Union._
       implicit val format = Macros.handlerOpts[UT, AllImplementations]
 
-      format.write(UA(1)).getAs[String]("className") must beSome("Macros.Union.UA")
-      format.write(UB("buzz")).getAs[String]("className") must beSome("Macros.Union.UB")
-
-      roundtripImp[UT](UA(17))
-      roundtripImp[UT](UB("foo"))
-      roundtripImp[UT](UC("bar"))
-      roundtripImp[UT](UD("baz"))
+      format.write(UA(1)).getAs[String]("className").
+        aka("class #1") must beSome("MacroTest.Union.UA") and {
+          format.write(UB("buzz")).getAs[String]("className").
+            aka("class #2") must beSome("MacroTest.Union.UB")
+        } and roundtripImp[UT](UA(17)) and roundtripImp[UT](UB("foo")) and {
+          roundtripImp[UT](UC("bar")) and roundtripImp[UT](UD("baz"))
+        }
     }
 
     "support automatic implementations search with nested traits" in {
@@ -289,12 +197,13 @@ class Macros extends Specification {
       import InheritanceModule._
       implicit val format = Macros.handlerOpts[T, AllImplementations]
 
-      format.write(A()).getAs[String]("className") must beSome("Macros.InheritanceModule.A")
-      format.write(B).getAs[String]("className") must beSome("Macros.InheritanceModule.B")
-
-      roundtripImp[T](A())
-      roundtripImp[T](B)
-      roundtripImp[T](C())
+      format.write(A()).getAs[String]("className").
+        aka("class #1") must beSome("MacroTest.InheritanceModule.A") and {
+          format.write(B).getAs[String]("className").
+            aka("class #2") must beSome("MacroTest.InheritanceModule.B")
+        } and {
+          roundtripImp[T](A()) and roundtripImp[T](B) and roundtripImp[T](C())
+        }
     }
 
     "automate Union on sealed traits with simple name" in {
@@ -305,10 +214,9 @@ class Macros extends Specification {
       format.write(UA(1)).getAs[String]("className") must beSome("UA")
       format.write(UB("buzz")).getAs[String]("className") must beSome("UB")
 
-      roundtripImp[UT](UA(17))
-      roundtripImp[UT](UB("foo"))
-      roundtripImp[UT](UC("bar"))
-      roundtripImp[UT](UD("baz"))
+      roundtripImp[UT](UA(17)) and roundtripImp[UT](UB("foo")) and {
+        roundtripImp[UT](UC("bar")) and roundtripImp[UT](UD("baz"))
+      }
     }
 
     "support automatic implementations search with nested traits with simple name" in {
@@ -319,9 +227,7 @@ class Macros extends Specification {
       format.write(A()).getAs[String]("className") must beSome("A")
       format.write(B).getAs[String]("className") must beSome("B")
 
-      roundtripImp[T](A())
-      roundtripImp[T](B)
-      roundtripImp[T](C())
+      roundtripImp[T](A()) and roundtripImp[T](B) and roundtripImp[T](C())
     }
 
     "support overriding keys with annotations" in {
@@ -334,33 +240,67 @@ class Macros extends Specification {
       println(BSONDocument.pretty(serialized))
        */
 
-      serialized mustEqual BSONDocument("_id" -> doc.myID, "value" -> doc.value)
-      format.read(serialized) mustEqual doc
+      serialized mustEqual (
+        BSONDocument("_id" -> doc.myID, "value" -> doc.value)
+      ) and {
+          format.read(serialized) must_== doc
+        }
     }
 
     "skip ignored fields" in {
+      val pairHandler = Macros.handler[Pair]
       val doc = pairHandler.write(Pair(left = "left", right = "right"))
 
-      doc.isEmpty must beFalse
-      doc.aka(BSONDocument.pretty(doc)) mustEqual BSONDocument("right" -> "right")
+      doc.isEmpty must beFalse and {
+        doc.aka(BSONDocument.pretty(doc)) must beTypedEqualTo(
+          BSONDocument("right" -> "right")
+        )
+      }
     }
   }
 
   "Reader" should {
     "throw meaningful exception if required field is missing" in {
       val personDoc = BSONDocument("firstName" -> "joe")
-      Macros.reader[Person].read(personDoc) must throwA[DocumentKeyNotFound].like {
-        case e => e.getMessage must contain("lastName")
-      }
+
+      Macros.reader[Person].read(personDoc) must throwA[DocumentKeyNotFound].
+        like { case e => e.getMessage must contain("lastName") }
     }
 
     "throw meaningful exception if field has another type" in {
-      val primitivesDoc = BSONDocument("dbl" -> 2D, "str" -> "str", "bl" -> true, "int" -> 2D, "long" -> 2L)
-      Macros.reader[Primitives].read(primitivesDoc) must throwA[ClassCastException].like {
-        case e =>
-          e.getMessage must contain(classOf[BSONDouble].getName)
-          e.getMessage must contain(classOf[BSONInteger].getName)
-      }
+      val primitivesDoc = BSONDocument(
+        "dbl" -> 2D, "str" -> "str", "bl" -> true, "int" -> 2D, "long" -> 2L
+      )
+
+      Macros.reader[Primitives].read(primitivesDoc).
+        aka("read") must throwA[ClassCastException].like {
+          case e =>
+            e.getMessage must contain(classOf[BSONDouble].getName) and {
+              e.getMessage must contain(classOf[BSONInteger].getName)
+            }
+        }
+    }
+
+    "be generated for a generated case class" in {
+      implicit def singleReader = Macros.reader[Single]
+      val r = Macros.reader[Foo[Single]]
+
+      r.read(BSONDocument(
+        "bar" -> BSONDocument("value" -> "A"),
+        "lorem" -> "ipsum"
+      )) must_== Foo(Single("A"), "ipsum")
     }
   }
+
+  // ---
+
+  def roundtrip[A](original: A, format: BSONReader[BSONDocument, A] with BSONWriter[A, BSONDocument]) = {
+    val serialized = format write original
+    val deserialized = format read serialized
+
+    original mustEqual deserialized
+  }
+
+  def roundtripImp[A](data: A)(implicit format: BSONReader[BSONDocument, A] with BSONWriter[A, BSONDocument]) = roundtrip(data, format)
+
 }

--- a/macros/src/test/scala/MacroTest.scala
+++ b/macros/src/test/scala/MacroTest.scala
@@ -1,0 +1,118 @@
+import reactivemongo.bson.{
+  BSONDocument,
+  BSONDocumentReader,
+  BSONDocumentWriter,
+  BSONHandler,
+  BSONObjectID,
+  Macros
+}
+import reactivemongo.bson.Macros.Annotations.{ Key, Ignore }
+
+object MacroTest {
+  type Handler[A] = BSONDocumentReader[A] with BSONDocumentWriter[A] with BSONHandler[BSONDocument, A]
+
+  case class Person(firstName: String, lastName: String)
+  case class Pet(name: String, owner: Person)
+  case class Primitives(dbl: Double, str: String, bl: Boolean, int: Int, long: Long)
+  case class Optional(name: String, value: Option[String])
+  case class Single(value: String)
+  case class OptionalSingle(value: Option[String])
+  case class SingleTuple(value: (String, String))
+  case class User(_id: BSONObjectID = BSONObjectID.generate(), name: String)
+  case class WordLover(name: String, words: Seq[String])
+  case class Empty()
+  object EmptyObject
+
+  case class RenamedId(
+    @Key("_id") myID: BSONObjectID = BSONObjectID.generate(),
+    @CustomAnnotation value: String
+  )
+
+  case class Foo[T](bar: T, lorem: String)
+
+  object Nest {
+    case class Nested(name: String)
+  }
+
+  case class OverloadedApply(string: String)
+  object OverloadedApply {
+    def apply(n: Int) = { /* println(n) */ }
+
+    def apply(seq: Seq[String]): OverloadedApply =
+      OverloadedApply(seq mkString " ")
+  }
+
+  object Union {
+    sealed trait UT
+    case class UA(n: Int) extends UT
+    case class UB(s: String) extends UT
+    case class UC(s: String) extends UT
+    case class UD(s: String) extends UT
+  }
+
+  trait NestModule {
+    case class Nested(name: String)
+    val format = Macros.handler[Nested]
+  }
+
+  object TreeModule {
+    /*
+    due to compiler limitations(read: only workaround I found), handlers must be defined here
+    and explicit type annotations added to enable compiler to use implicit handlers recursively
+     */
+
+    sealed trait Tree
+    case class Node(left: Tree, right: Tree) extends Tree
+    case class Leaf(data: String) extends Tree
+
+    object Tree {
+      import Macros.Options._
+      implicit val bson: Handler[Tree] =
+        Macros.handlerOpts[Tree, UnionType[Node \/ Leaf]]
+    }
+  }
+
+  object TreeCustom {
+    sealed trait Tree
+    case class Node(left: Tree, right: Tree) extends Tree
+    case class Leaf(data: String) extends Tree
+
+    object Leaf {
+      private val helper = Macros.handler[Leaf]
+      implicit val bson: Handler[Leaf] = new BSONDocumentReader[Leaf] with BSONDocumentWriter[Leaf] with BSONHandler[BSONDocument, Leaf] {
+        def write(t: Leaf): BSONDocument = helper.write(Leaf("hai"))
+        def read(bson: BSONDocument): Leaf = helper read bson
+      }
+    }
+
+    object Tree {
+      import Macros.Options._
+
+      implicit val bson: Handler[Tree] =
+        Macros.handlerOpts[Tree, UnionType[Node \/ Leaf]]
+      //Macros.handlerOpts[Tree, UnionType[Node \/ Leaf] with Verbose]
+    }
+  }
+
+  object IntListModule {
+    sealed trait IntList
+    case class Cons(head: Int, tail: IntList) extends IntList
+    case object Tail extends IntList
+
+    object IntList {
+      import Macros.Options.{ UnionType, \/ }
+
+      implicit val bson: Handler[IntList] = Macros.handlerOpts[IntList, UnionType[Cons \/ Tail.type]]
+    }
+  }
+
+  object InheritanceModule {
+    sealed trait T
+    case class A() extends T
+    case object B extends T
+    sealed trait TT extends T
+    case class C() extends TT
+  }
+
+  case class Pair(@Ignore left: String, right: String)
+}


### PR DESCRIPTION
```scala
// Entering paste mode (ctrl-D to finish)

import reactivemongo.bson._

case class Foo[A](bar: List[A])

object Foo {
  def bsonReader[A : BSONDocumentReader] = Macros.reader[Foo[A]]
}
```

```
error: No matching apply/unapply found
         def bsonReader[A : BSONDocumentReader] = Macros.reader[Foo[A]]
```