### PR TITLE
Fixing classloader issue

### DIFF
--- a/driver/src/main/scala/api/api.scala
+++ b/driver/src/main/scala/api/api.scala
@@ -755,7 +755,7 @@ object MongoConnection {
 /**
  * @param config a custom configuration (otherwise the default options are used)
  */
-class MongoDriver(config: Option[Config] = None) {
+class MongoDriver(config: Option[Config] = None, classLoader: Option[ClassLoader] = None) {
   import scala.collection.mutable.{ Map => MutableMap }
 
   import MongoDriver.logger
@@ -772,7 +772,7 @@ class MongoDriver(config: Option[Config] = None) {
       ConfigFactory.empty()
     } else reference.getConfig("mongo-async-driver")
 
-    ActorSystem("reactivemongo", cfg)
+    ActorSystem("reactivemongo", Some(cfg), classLoader)
   }
 
   private val supervisorName = s"Supervisor-${MongoDriver.nextCounter}"
@@ -976,8 +976,10 @@ object MongoDriver {
   /** Creates a new [[MongoDriver]] with a new ActorSystem. */
   def apply(): MongoDriver = new MongoDriver
 
+  def withClassLoader(classLoader: ClassLoader) = new MongoDriver(classLoader = Some(classLoader))
+
   /** Creates a new [[MongoDriver]] with the given `config`. */
-  def apply(config: Config): MongoDriver = new MongoDriver(Some(config))
+  def apply(config: Config, classLoader: Option[ClassLoader] = None): MongoDriver = new MongoDriver(Some(config), classLoader)
 
   private[api] val _counter = new AtomicLong(0)
   private[api] def nextCounter: Long = _counter.incrementAndGet()


### PR DESCRIPTION
## Fixes

SBT has a dynamic classloader which allows reloading classes in the same JVM. Such a classloader conflicts with Akka requirement of having a stable classloader and running multiple times the same test or simply a multi-module build can trigger a classloader failure with this stacktrace:

```
[error] ! 
[error]  java.lang.ClassCastException: interface akka.event.LoggingFilter is not assignable from class akka.event.DefaultLoggingFilter (ReflectiveDynamicAccess.scala:23)
[error] akka.actor.ReflectiveDynamicAccess$$anonfun$getClassFor$1.apply(ReflectiveDynamicAccess.scala:23)
[error] akka.actor.ReflectiveDynamicAccess$$anonfun$getClassFor$1.apply(ReflectiveDynamicAccess.scala:20)
[error] akka.actor.ReflectiveDynamicAccess.getClassFor(ReflectiveDynamicAccess.scala:20)
[error] akka.actor.ReflectiveDynamicAccess.createInstanceFor(ReflectiveDynamicAccess.scala:38)
[error] akka.actor.ActorSystemImpl.<init>(ActorSystem.scala:597)
[error] akka.actor.ActorSystem$.apply(ActorSystem.scala:142)
[error] akka.actor.ActorSystem$.apply(ActorSystem.scala:109)
```

## Purpose

In order to overcome such a problem, the ActorSystem.apply method supports an Option[Classloader].  If a stable classloader (which you can retrieve with classOf[MyClass].getClassLoader())  is passed in, the problem is solved.

