### PR TITLE
Missing md5 hash in GridFS

### DIFF
--- a/driver/src/test/scala/GridfsSpec.scala
+++ b/driver/src/test/scala/GridfsSpec.scala
@@ -7,6 +7,7 @@ import reactivemongo.api.BSONSerializationPack
 import reactivemongo.api.gridfs.{ ReadFile, DefaultFileToSave, GridFS }
 import reactivemongo.api.gridfs.Implicits._
 import reactivemongo.bson._
+import reactivemongo.bson.utils.Converters
 
 import org.specs2.concurrent.{ ExecutionEnv => EE }
 
@@ -30,37 +31,57 @@ class GridFSSpec extends org.specs2.mutable.Specification {
   type GFile = ReadFile[BSONSerializationPack.type, BSONValue]
 
   def gridFsSpec(gfs: GridFS[BSONSerializationPack.type], timeout: FiniteDuration) = {
-    val filename = s"somefile${System identityHashCode gfs}"
-    lazy val file = DefaultFileToSave(Some(filename), Some("application/file"))
+    val filename1 = s"file1-${System identityHashCode gfs}"
+    lazy val file1 = DefaultFileToSave(Some(filename1), Some("application/file"))
+    lazy val content1 = (1 to 100).view.map(_.toByte).toArray
 
-    lazy val fileContent = Enumerator((1 to 100).view.map(_.toByte).toArray)
-
-    "store a file" in { implicit ee: EE =>
-      gfs.save(fileContent, file).map(_.filename).
-        aka("filename") must beSome(filename).await(1, timeout)
+    "store a file without a computed MD5" in { implicit ee: EE =>
+      gfs.save(Enumerator(content1), file1).map(_.filename).
+        aka("filename") must beSome(filename1).await(1, timeout)
     }
 
-    "find this file" in { implicit ee: EE =>
-      def f: Future[Option[GFile]] =
-        gfs.find(BSONDocument("filename" -> filename)).headOption
+    val filename2 = s"file2-${System identityHashCode content1}"
+    lazy val file2 = DefaultFileToSave(Some(filename2), Some("text/plain"))
+    lazy val content2 = (100 to 200).view.map(_.toByte).toArray
 
-      f must beSome[GFile].which { actual =>
-        actual.filename mustEqual file.filename and (
-          actual.uploadDate must beSome
-        ) and (actual.contentType mustEqual file.contentType) and {
-            import scala.collection.mutable.ArrayBuilder
-            def res = gfs.enumerate(actual) |>>>
-              Iteratee.fold(ArrayBuilder.make[Byte]()) { _ ++= _ }
-
-            res.map(_.result()) must beEqualTo(
-              (1 to 100).map(_.toByte).toArray
-            ).await(1, timeout)
-          }
-      }.await(1, timeout)
+    "store a file with computed MD5" in { implicit ee: EE =>
+      gfs.saveWithMD5(Enumerator(content2), file2).map(_.filename).
+        aka("filename") must beSome(filename2).await(1, timeout)
     }
 
-    "delete this file from GridFS" in { implicit ee: EE =>
-      gfs.remove(file.id).map(_.n) must beEqualTo(1).await(1, timeout)
+    "find the files" in { implicit ee: EE =>
+      def find(n: String): Future[Option[GFile]] =
+        gfs.find(BSONDocument("filename" -> n)).headOption
+
+      def matchFile(actual: GFile, expected: DefaultFileToSave, content: Array[Byte]) = actual.filename must_== expected.filename and (
+        actual.uploadDate must beSome
+      ) and (actual.contentType must_== expected.contentType) and {
+          import scala.collection.mutable.ArrayBuilder
+          def res = gfs.enumerate(actual) |>>>
+            Iteratee.fold(ArrayBuilder.make[Byte]()) { _ ++= _ }
+
+          res.map(_.result()) must beEqualTo(content).await(1, timeout)
+        }
+
+      find(filename1) aka "file #1" must beSome[GFile].
+        which(matchFile(_, file1, content1)).await(1, timeout) and {
+          find(filename2) aka "file #2" must beSome[GFile].which { actual =>
+            def expectedMd5 = Converters.hex2Str(Converters.md5(content2))
+
+            matchFile(actual, file2, content2) and {
+              actual.md5 must beSome[String].which {
+                _ aka "MD5" must_== expectedMd5
+              }
+            }
+          }.await(1, timeout)
+        }
+    }
+
+    "delete the files from GridFS" in { implicit ee: EE =>
+      (for {
+        a <- gfs.remove(file1.id).map(_.n)
+        b <- gfs.remove(file2.id).map(_.n)
+      } yield a + b) must beEqualTo(2).await(1, timeout)
     }
   }
 }


### PR DESCRIPTION
There is no md5 hash calculated when storing a file to GridFS. Seems that part is commented out in the current RM codebase.