### PR TITLE
Fix macro with generic sequence

### DIFF
--- a/bson/src/main/scala/bson.scala
+++ b/bson/src/main/scala/bson.scala
@@ -49,6 +49,9 @@ object `package` extends DefaultBSONHandlers {
   def generateId = BSONObjectID.generate()
 
   def element(name: String, value: BSONValue) = BSONElement(name, value)
+
+  /** Convenient type alias for document handlers */
+  type BSONDocumentHandler[T] = BSONDocumentReader[T] with BSONDocumentWriter[T] with BSONHandler[BSONDocument, T]
 }
 
 object BSON {

--- a/macros/src/main/scala/Macros.scala
+++ b/macros/src/main/scala/Macros.scala
@@ -31,13 +31,13 @@ object Macros {
   def writerOpts[A, Opts <: Options.Default]: BSONDocumentWriter[A] = macro MacroImpl.writer[A, Opts]
 
   /** Creates an instance of BSONReader and BSONWriter for case class A */
-  def handler[A]: BSONDocumentReader[A] with BSONDocumentWriter[A] with BSONHandler[BSONDocument, A] = macro MacroImpl.handler[A, Options.Default]
+  def handler[A]: BSONDocumentHandler[A] = macro MacroImpl.handler[A, Options.Default]
 
   /**
    * Creates an instance of BSONReader and BSONWriter for case class A,
    * and takes additional options.
    */
-  def handlerOpts[A, Opts <: Options.Default]: BSONDocumentReader[A] with BSONDocumentWriter[A] with BSONHandler[BSONDocument, A] = macro MacroImpl.handler[A, Opts]
+  def handlerOpts[A, Opts <: Options.Default]: BSONDocumentHandler[A] = macro MacroImpl.handler[A, Opts]
 
   /**
    * Methods with 'Opts' postfix will take additional options in the form of

--- a/macros/src/test/scala/MacroTest.scala
+++ b/macros/src/test/scala/MacroTest.scala
@@ -34,6 +34,8 @@ object MacroTest {
   case class Foo[T](bar: T, lorem: String)
   case class Bar(name: String, next: Option[Bar])
 
+  case class GenSeq[A](items: Seq[A], count: Int)
+
   object Nest {
     case class Nested(name: String)
   }


### PR DESCRIPTION
```
Implicit reactivemongo.bson.BSONReader[scala.collection.Seq] not found for 'items'
        Macros.handler[GenSeq[T]]
                      ^
type mismatch;
 found   : reactivemongo.bson.BSONReader[reactivemongo.bson.BSONArray,Seq[MacroTest.Single]]
 required: reactivemongo.bson.BSONReader[_ <: reactivemongo.bson.BSONValue, Seq[A]]
      roundtrip(GenSeq(Seq(Single("A")), 1), Macros.handler[GenSeq[Single]])
```