### PR TITLE
Macros.handler vs Macros.handleOpts for sealed trait

### DIFF
--- a/macros/src/main/scala-2.11/MacroImpl.scala
+++ b/macros/src/main/scala-2.11/MacroImpl.scala
@@ -36,10 +36,11 @@ private object MacroImpl {
     })
   }
 
-  private def Helper[A: c.WeakTypeTag, Opts: c.WeakTypeTag](c: Context) = new Helper[c.type, A](c) {
-    val A = c.weakTypeOf[A]
-    val Opts = c.weakTypeOf[Opts]
-  }
+  private def Helper[A: c.WeakTypeTag, Opts: c.WeakTypeTag](c: Context) =
+    new Helper[c.type, A](c) {
+      val A = c.weakTypeOf[A]
+      val Opts = c.weakTypeOf[Opts]
+    }
 
   private abstract class Helper[C <: Context, A](
     val c: C
@@ -157,16 +158,15 @@ private object MacroImpl {
       val (writer, _) = r(tpe)
 
       if (!writer.isEmpty) {
-        val doc = q"$writer.write(document)"
+        @inline def doc = q"$writer.write(document)"
 
-        classNameTree(tpe) map { className =>
-          val nameE = c.Expr[(String, BSONString)](className)
+        classNameTree(tpe).fold(doc) { nameE =>
           val docE = c.Expr[BSONDocument](doc)
 
           reify {
             docE.splice ++ BSONDocument(Seq(nameE.splice))
           }.tree
-        } getOrElse doc
+        }
       } else writeBodyConstruct(tpe)
     }
 
@@ -175,8 +175,7 @@ private object MacroImpl {
       else writeBodyConstructClass(tpe)
 
     private def writeBodyConstructSingleton(tpe: Type): Tree = (
-      classNameTree(tpe) map { className =>
-        val nameE = c.Expr[(String, BSONString)](className)
+      classNameTree(tpe) map { nameE =>
         reify { BSONDocument(Seq((nameE.splice))) }
       } getOrElse reify { BSONDocument.empty }
       ).tree
@@ -239,7 +238,8 @@ private object MacroImpl {
 
       }
 
-      val mkBSONdoc = Apply(bsonDocPath, values ++ classNameTree(tpe))
+      val mkBSONdoc = Apply(
+        bsonDocPath, values ++ classNameTree(tpe).map(_.tree))
 
       val writer = {
         if (optional.isEmpty) List(mkBSONdoc)
@@ -258,16 +258,19 @@ private object MacroImpl {
       } else writer.head
     }
 
-    private def classNameTree(A: c.Type) = {
-      if (hasOption[Macros.Options.SaveClassName]) Some {
-        val name = if (hasOption[Macros.Options.SaveSimpleName])
-          c.Expr[String](q"${A.typeSymbol.name.decodedName.toString}")
-        else
-          c.Expr[String](q"${A.typeSymbol.fullName}")
+    private def classNameTree(tpe: c.Type): Option[c.Expr[(String, BSONString)]] = {
+      val tpeSym = A.typeSymbol.asClass
 
-        reify(("className", BSONStringHandler.write(name.splice))).tree
-      }
-      else None
+      println(s"_here: $tpeSym -> ${tpeSym.isSealed}, ${tpeSym.isAbstract}")
+
+      if (hasOption[Macros.Options.SaveClassName] ||
+        tpeSym.isSealed && tpeSym.isAbstract) Some {
+        val name = if (hasOption[Macros.Options.SaveSimpleName]) {
+          c.Expr[String](q"${tpe.typeSymbol.name.decodedName.toString}")
+        } else c.Expr[String](q"${tpe.typeSymbol.fullName}")
+
+        reify(("className", BSONStringHandler.write(name.splice)))
+      } else None
     }
 
     private lazy val unionTypes: Option[List[c.Type]] =

--- a/macros/src/main/scala/Macros.scala
+++ b/macros/src/main/scala/Macros.scala
@@ -47,7 +47,7 @@ object Macros {
   object Options {
 
     /**
-     * Default options that are implied if invoking "non-Opts" method.
+     * The default options that are implied if invoking "non-Opts" method.
      * All other options extend this.
      */
     trait Default
@@ -56,9 +56,10 @@ object Macros {
     trait Verbose extends Default
 
     /**
-     * In `write` method also store class name(dynamic type) as a string
+     * In `write` method also store class name (dynamic type) as a string
      * in a property named "className".
      */
+    @deprecated(message = "Default behaviour for sealed trait, if union types are not explicitly defined", since = "0.12-RC2")
     trait SaveClassName extends Default
 
     /**
@@ -86,7 +87,8 @@ object Macros {
      * fully-qualified name.
      * @tparam Types to use in pattern matching. Listed in a "type list" \/
      */
-    trait SimpleUnionType[Types <: \/[_, _]] extends UnionType[Types] with SaveSimpleName with Default
+    trait SimpleUnionType[Types <: \/[_, _]]
+      extends UnionType[Types] with SaveSimpleName with Default
 
     /**
      * Type for making type-level lists for UnionType.
@@ -110,7 +112,8 @@ object Macros {
      * (e.g. the fully-qualified name).
      */
     @deprecated(message = "Default behaviour for sealed trait, if union types are not explicitly defined", since = "0.12-RC2")
-    trait SimpleAllImplementations extends AllImplementations with SaveSimpleName with Default
+    trait SimpleAllImplementations
+      extends AllImplementations with SaveSimpleName with Default
   }
 
   /** Annotations to use on case classes that are being processed by macros. */

--- a/macros/src/test/scala/MacroSpec.scala
+++ b/macros/src/test/scala/MacroSpec.scala
@@ -212,7 +212,7 @@ class MacroSpec extends org.specs2.mutable.Specification {
     "automate Union on sealed traits" in {
       import Macros.Options._
       import Union._
-      implicit val format = Macros.handlerOpts[UT, AllImplementations]
+      implicit val format = Macros.handler[UT]
 
       format.write(UA(1)).getAs[String]("className").
         aka("class #1") must beSome("MacroTest.Union.UA") and {
@@ -221,7 +221,7 @@ class MacroSpec extends org.specs2.mutable.Specification {
         } and roundtripImp[UT](UA(17)) and roundtripImp[UT](UB("foo")) and {
           roundtripImp[UT](UC("bar")) and roundtripImp[UT](UD("baz"))
         } and roundtripImp[UT](UF)
-    }
+    } tag "wip"
 
     "support automatic implementations search with nested traits" in {
       import Macros.Options._

--- a/project/ReactiveMongo.scala
+++ b/project/ReactiveMongo.scala
@@ -3,7 +3,7 @@ import sbt.Keys._
 import scala.language.postfixOps
 
 object BuildSettings {
-  val nextMajor = "0.12.1"
+  val nextMajor = "0.12.2"
   val buildVersion = s"$nextMajor-SNAPSHOT"
 
   val filter = { (ms: Seq[(File, String)]) =>
@@ -80,7 +80,8 @@ object Publish {
 
   val mimaSettings = mimaDefaultSettings ++ Seq(
     previousArtifacts := {
-      if (crossPaths.value) {
+      if (scalaVersion.value startsWith "2.12.") Set.empty
+      else if (crossPaths.value) {
         Set(organization.value % s"${moduleName.value}_${scalaBinaryVersion.value}" % previousVersion)
       } else {
         Set(organization.value % moduleName.value % previousVersion)


### PR DESCRIPTION
``` scala
sealed trait Foo
case object Bar extends Foo
case object Lorem extends Foo

import reactivemongo.bson.{ Macros, BSONDocument }, BSONDocument.pretty

val h1 = Macros.handler[Foo]
val h2 = Macros.handlerOpts[Foo, Macros.Options.AllImplementations]

pretty(h1.write(Bar))
/*
{

}
*/

pretty(h2.write(Bar))
/*
{
  className: "Bar"
}
*/
```
