### PR TITLE
implement mongo authentication for x509 certificates

### DIFF
--- a/driver/src/main/scala/api/MongoConnectionOptions.scala
+++ b/driver/src/main/scala/api/MongoConnectionOptions.scala
@@ -11,6 +11,9 @@ case object CrAuthentication extends AuthenticationMode
 /** SCRAM-SHA-1 authentication (see MongoDB 3.0) */
 case object ScramSha1Authentication extends AuthenticationMode
 
+/** X509 authentication */
+case object X509Authentication extends AuthenticationMode
+
 /**
  * Options for MongoConnection.
  *

--- a/driver/src/main/scala/core/actors.scala
+++ b/driver/src/main/scala/core/actors.scala
@@ -1245,29 +1245,13 @@ trait MongoDBSystem extends Actor {
 }
 
 @deprecated("Internal class: will be made private", "0.11.14")
-final class LegacyDBSystem private[reactivemongo] (
+abstract class StandardDBSystem private[reactivemongo] (
     val supervisor: String,
     val name: String,
     val seeds: Seq[String],
     val initialAuthenticates: Seq[Authenticate],
     val options: MongoConnectionOptions
-) extends MongoDBSystem with MongoCrAuthentication {
-
-  def newChannelFactory(effect: Unit): ChannelFactory =
-    new ChannelFactory(supervisor, name, options)
-
-  @deprecated("Initialize with an explicit supervisor and connection names", "0.11.14")
-  def this(s: Seq[String], a: Seq[Authenticate], opts: MongoConnectionOptions) = this(s"unknown-${System identityHashCode opts}", s"unknown-${System identityHashCode opts}", s, a, opts)
-}
-
-@deprecated("Internal class: will be made private", "0.11.14")
-final class StandardDBSystem private[reactivemongo] (
-    val supervisor: String,
-    val name: String,
-    val seeds: Seq[String],
-    val initialAuthenticates: Seq[Authenticate],
-    val options: MongoConnectionOptions
-) extends MongoDBSystem with MongoScramSha1Authentication {
+) extends MongoDBSystem {
 
   def newChannelFactory(effect: Unit): ChannelFactory =
     new ChannelFactory(supervisor, name, options)

--- a/driver/src/main/scala/core/authentication.scala
+++ b/driver/src/main/scala/core/authentication.scala
@@ -15,6 +15,27 @@ import reactivemongo.core.nodeset.{
   ScramSha1Authenticating
 }
 
+private[reactivemongo] trait MongoX509Authentication { system: MongoDBSystem =>
+  import reactivemongo.core.commands.{ X509Authenticate }
+  import reactivemongo.core.nodeset.X509Authenticating
+  import MongoDBSystem.logger
+
+  protected final def sendAuthenticate(connection: Connection, nextAuth: Authenticate): Connection = {
+    connection.send(X509Authenticate(nextAuth.user)("$external").maker(RequestId.authenticate.next))
+
+    connection.copy(authenticating = Some(
+      X509Authenticating(nextAuth.db, nextAuth.user)
+    ))
+  }
+
+  protected val authReceive: Receive = {
+    case response: Response if RequestId.authenticate accepts response =>
+      logger.debug(s"AUTH: got authenticated response! ${response.info.channelId}")
+      authenticationResponse(response)(X509Authenticate.parseResponse(_))
+  }
+
+}
+
 private[reactivemongo] trait MongoCrAuthentication { system: MongoDBSystem =>
   import reactivemongo.core.commands.{ CrAuthenticate, GetCrNonce }
   import MongoDBSystem.logger

--- a/driver/src/main/scala/core/commands/authentication.scala
+++ b/driver/src/main/scala/core/commands/authentication.scala
@@ -356,6 +356,29 @@ object CrAuthenticate extends BSONCommandResultMaker[SuccessfulAuthentication] {
   }
 }
 
+// --- MongoDB X509 authentication ---
+
+private[core] case class X509Authenticate(user: String) extends Command[SuccessfulAuthentication] {
+
+  override def makeDocuments = BSONDocument(
+    "authenticate" -> BSONInteger(1),
+    "mechanism" -> BSONString("MONGODB-X509"),
+    "user" -> BSONString(user)
+  )
+
+  override val ResultMaker = X509Authenticate
+}
+
+object X509Authenticate extends BSONCommandResultMaker[SuccessfulAuthentication] {
+  def parseResponse(response: Response): Either[CommandError, SuccessfulAuthentication] = apply(response)
+
+  def apply(document: BSONDocument) = {
+    CommandError.checkOk(document, Some("authenticate"), (doc, name) => {
+      FailedAuthentication(doc.getAs[BSONString]("errmsg").map(_.value).getOrElse(""), Some(doc))
+    }).toLeft(SilentSuccessfulAuthentication)
+  }
+}
+
 /** an authentication result */
 sealed trait AuthenticationResult
 

--- a/driver/src/main/scala/core/nodeset.scala
+++ b/driver/src/main/scala/core/nodeset.scala
@@ -479,7 +479,7 @@ case class Authenticate(
 }
 
 sealed trait Authenticating extends Authentication {
-  def password: String
+  override def toString: String = s"Authenticating($db, $user})"
 }
 
 object Authenticating {
@@ -494,6 +494,8 @@ object Authenticating {
       case ScramSha1Authenticating(db, user, pass, _, _, _, _, _) =>
         Some((db, user, pass))
 
+      case X509Authenticating(db, user) => Some((db, user, ""))
+
       case _ =>
         None
     }
@@ -505,16 +507,14 @@ case class CrAuthenticating(db: String, user: String, password: String, nonce: O
 }
 
 case class ScramSha1Authenticating(
-    db: String, user: String, password: String,
-    randomPrefix: String, saslStart: String,
-    conversationId: Option[Int] = None,
-    serverSignature: Option[Array[Byte]] = None,
-    step: Int = 0
-) extends Authenticating {
+  db: String, user: String, password: String,
+  randomPrefix: String, saslStart: String,
+  conversationId: Option[Int] = None,
+  serverSignature: Option[Array[Byte]] = None,
+  step: Int = 0
+) extends Authenticating
 
-  override def toString: String =
-    s"Authenticating($db, $user})"
-}
+case class X509Authenticating(db: String, user: String) extends Authenticating
 
 case class Authenticated(db: String, user: String) extends Authentication
 

--- a/driver/src/test/scala/ApiTesting.scala
+++ b/driver/src/test/scala/ApiTesting.scala
@@ -11,7 +11,8 @@ import reactivemongo.core.nodeset.{ Authenticate, NodeSet }
 import reactivemongo.core.actors.{
   ChannelClosed,
   MongoDBSystem,
-  StandardDBSystem
+  StandardDBSystem,
+  MongoScramSha1Authentication
 }
 
 package object tests {
@@ -22,7 +23,8 @@ package object tests {
 
   def waitIsAvailable(con: MongoConnection, failoverStrategy: FailoverStrategy)(implicit ec: ExecutionContext): Future[Unit] = con.waitIsAvailable(failoverStrategy)
 
-  def standardDBSystem(supervisor: String, name: String, nodes: Seq[String], authenticates: Seq[Authenticate], options: MongoConnectionOptions) = new StandardDBSystem(supervisor, name, nodes, authenticates, options)
+  def standardDBSystem(supervisor: String, name: String, nodes: Seq[String], authenticates: Seq[Authenticate], options: MongoConnectionOptions) =
+    new StandardDBSystem(supervisor, name, nodes, authenticates, options) with MongoScramSha1Authentication
 
   def addConnection(d: MongoDriver, name: String, nodes: Seq[String], options: MongoConnectionOptions, mongosystem: ActorRef): Future[Any] = {
     import akka.pattern.ask


### PR DESCRIPTION
# Pull Request Checklist
 
* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)? yes
* [x] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)? yes
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)? only one anyway
* [ ] Have you added tests for any changed functionality? not yet

## Fixes

Fixes #462 

Hi @cchantep I've implemented auth for X509 will be adding tests to DriverSpec but wanted to get your opinion on the implementation earlier. Also thinking another configuration in the travis matrix would be a good idea, that will give it more thorough coverage, what do you think?

I'll also be updating the docs