### PR TITLE
Make WriteResult.lastError detect/return any error. Fix #622

### DIFF
--- a/driver/src/main/scala/api/commands/writeresult.scala
+++ b/driver/src/main/scala/api/commands/writeresult.scala
@@ -32,8 +32,7 @@ sealed trait WriteResult {
 object WriteResult {
   def lastError(result: WriteResult): Option[LastError] = result match {
     case error @ LastError(_, _, _, _, _, _, _, _, _, _, _, _, _, _) => Some(error)
-    case _ if (result.ok) => None
-    case _ => Some(LastError(
+    case _ if result.inError || result.hasErrors => Some(LastError(
       false, // ok
       result.errmsg,
       result.code,
@@ -49,6 +48,7 @@ object WriteResult {
       result.writeErrors,
       result.writeConcernError
     ))
+    case _ => None
   }
 
   /**


### PR DESCRIPTION
While doing ordered bulk inserts I noticed that an error on a individual document get lost into a `GenericDriverException`.
I'd rather have a more structured `LastError`. (because I need to recover from duplicate key errors)

The reason of the behavior is that in `reactivemongo.api.collections.GenericCollection.Mongo26WriteCommand#send` we have:
```scala
       case Some(wr) if (wr.inError || (wr.hasErrors && ordered)) => {
          Future.failed(WriteResult.lastError(wr).
            getOrElse[Exception](GenericDriverException(
              s"write failure: $wr"
            )))
        }
```
and in `reactivemongo.api.commands.WriteResult#lastError`:
```scala
  def lastError(result: WriteResult): Option[LastError] = result match {
    case error @ LastError(_, _, _, _, _, _, _, _, _, _, _, _, _, _) => Some(error)
    case _ if (result.ok) => None
    case _ => Some(LastError(
      false, // ok
      result.errmsg,
```
Eg, if mongo (tested with 3.2) fail to insert a document due to a duplicate key, it will return an response like:
```
{
  ok: BSONInteger(1),
  n: BSONInteger(0),
  writeErrors: [
    0: {
      index: BSONInteger(0),
      code: BSONInteger(11000),
      errmsg: "E11000 duplicate key error collection: test.events index: _id_ dup key: { : { key: ObjectId('56c6dc1eff2e140920771ee5'), seq: 12 } }"
    }
  ]
}
```

Has we can see, the corresponding write result will be "`ok`" despite `writeErrors` being non-empty. Hence we fall in the `getOrElse` clause resulting in errors being mangled into a `GenericDriverException`.