### PR TITLE
Fix scaladoc of Macros.Options.SaveSimpleName

### DIFF
--- a/macros/src/main/scala/Macros.scala
+++ b/macros/src/main/scala/Macros.scala
@@ -64,7 +64,7 @@ object Macros {
 
     /**
      * Same as [[SaveClassName]] but using the class simple name
-     * (e.g. the fully-qualified name).
+     * (i.e. Not the fully-qualified name).
      */
     trait SaveSimpleName extends SaveClassName with Default
 


### PR DESCRIPTION
documentation fix: `SaveSimpleName` is for NOT using the fully-qualified class name.