### PR TITLE
Add defaut handler for Map[K,V]

### DIFF
--- a/bson/src/main/scala/Handlers.scala
+++ b/bson/src/main/scala/Handlers.scala
@@ -378,6 +378,26 @@ trait DefaultBSONHandlers {
 
   implicit def findReader[T](implicit reader: VariantBSONReader[_ <: BSONValue, T]): BSONReader[_ <: BSONValue, T] =
     new VariantBSONReaderWrapper(reader)
+
+  implicit def MapReader[K, V](implicit kr: BSONReader[BSONString, K], vr: BSONReader[_ <: BSONValue, V]): BSONDocumentReader[Map[K, V]] =
+    new BSONDocumentReader[Map[K, V]] {
+      def read(bson: BSONDocument): Map[K, V] = {
+        val elements = bson.elements.map { element =>
+          kr.read(BSONString(element.name)) -> element.value.seeAsTry[V].get
+        }
+        elements.toMap
+      }
+    }
+
+  implicit def MapWriter[K, V](implicit kr: BSONWriter[K, BSONString], vw: BSONWriter[V, _ <: BSONValue]): BSONDocumentWriter[Map[K, V]] =
+    new BSONDocumentWriter[Map[K, V]] {
+      def write(map: Map[K, V]) = {
+        val elements = map.toStream.map { tuple =>
+          BSONElement(kr.write(tuple._1).value, vw.write(tuple._2))
+        }
+        BSONDocument(elements)
+      }
+    }
 }
 
 object DefaultBSONHandlers extends DefaultBSONHandlers

--- a/bson/src/main/scala/Handlers.scala
+++ b/bson/src/main/scala/Handlers.scala
@@ -392,7 +392,7 @@ trait DefaultBSONHandlers {
   implicit def MapWriter[K, V](implicit keyWriter: BSONWriter[K, BSONString], valueWriter: BSONWriter[V, _ <: BSONValue]): BSONDocumentWriter[Map[K, V]] =
     new BSONDocumentWriter[Map[K, V]] {
       def write(inputMap: Map[K, V]): BSONDocument = {
-        val elements = inputMap.toStream.map { tuple =>
+        val elements = inputMap.map { tuple =>
           BSONElement(keyWriter.write(tuple._1).value, valueWriter.write(tuple._2))
         }
         BSONDocument(elements)

--- a/bson/src/test/scala/Handlers.scala
+++ b/bson/src/test/scala/Handlers.scala
@@ -156,12 +156,15 @@ class Handlers extends org.specs2.mutable.Specification {
     "write primitives values" in {
       val input = Map("a" -> 1, "b" -> 2)
       val result = DefaultBSONHandlers.MapWriter(BSONStringHandler, BSONIntegerHandler).write(input)
+
       result mustEqual BSONDocument("a" -> 1, "b" -> 2)
     }
-
+    
     "read primitives values" in {
       val input = BSONDocument("a" -> 1, "b" -> 2)
-      val result = DefaultBSONHandlers.MapReader(BSONStringHandler, BSONIntegerHandler).read(input)
+      val handler = implicitly[BSONReader[BSONDocument, Map[String, Int]]]
+      val result = handler.read(input)
+
       result mustEqual Map("a" -> 1, "b" -> 2)
     }
 
@@ -182,6 +185,7 @@ class Handlers extends org.specs2.mutable.Specification {
       )
       val input = Map("a" -> Foo("foo", 10), "b" -> Foo("foo2", 20))
       val result = DefaultBSONHandlers.MapWriter(BSONStringHandler, fooWriter).write(input)
+
       result mustEqual expectedResult
     }
 
@@ -191,7 +195,9 @@ class Handlers extends org.specs2.mutable.Specification {
         "a" -> BSONDocument("label" -> "foo", "count" -> 10),
         "b" -> BSONDocument("label" -> "foo2", "count" -> 20)
       )
-      val result = DefaultBSONHandlers.MapReader(BSONStringHandler, fooReader).read(input)
+      val handler = implicitly[BSONReader[BSONDocument, Map[String, Foo]]]
+      val result = handler.read(input)
+
       result mustEqual expectedResult
     }
   }

--- a/bson/src/test/scala/Handlers.scala
+++ b/bson/src/test/scala/Handlers.scala
@@ -152,6 +152,50 @@ class Handlers extends org.specs2.mutable.Specification {
     }
   }
 
+  "Map" should {
+    "write primitives values" in {
+      val input = Map("a" -> 1, "b" -> 2)
+      val result = DefaultBSONHandlers.MapWriter(BSONStringHandler, BSONIntegerHandler).write(input)
+      result mustEqual BSONDocument("a" -> 1, "b" -> 2)
+    }
+
+    "read primitives values" in {
+      val input = BSONDocument("a" -> 1, "b" -> 2)
+      val result = DefaultBSONHandlers.MapReader(BSONStringHandler, BSONIntegerHandler).read(input)
+      result mustEqual Map("a" -> 1, "b" -> 2)
+    }
+
+    case class Foo(label: String, count: Int)
+    val fooWriter = BSONDocumentWriter[Foo] { foo => BSONDocument("label" -> foo.label, "count" -> foo.count) }
+    val fooReader = BSONDocumentReader[Foo] { document =>
+      val foo = for {
+        label <- document.getAs[String]("label")
+        count <- document.getAs[Int]("count")
+      } yield Foo(label, count)
+      foo.get
+    }
+
+    "write complex values" in {
+      val expectedResult = BSONDocument(
+        "a" -> BSONDocument("label" -> "foo", "count" -> 10),
+        "b" -> BSONDocument("label" -> "foo2", "count" -> 20)
+      )
+      val input = Map("a" -> Foo("foo", 10), "b" -> Foo("foo2", 20))
+      val result = DefaultBSONHandlers.MapWriter(BSONStringHandler, fooWriter).write(input)
+      result mustEqual expectedResult
+    }
+
+    "read complex values" in {
+      val expectedResult = Map("a" -> Foo("foo", 10), "b" -> Foo("foo2", 20))
+      val input = BSONDocument(
+        "a" -> BSONDocument("label" -> "foo", "count" -> 10),
+        "b" -> BSONDocument("label" -> "foo2", "count" -> 20)
+      )
+      val result = DefaultBSONHandlers.MapReader(BSONStringHandler, fooReader).read(input)
+      result mustEqual expectedResult
+    }
+  }
+
   "BSONDateTime" should {
     val time = System.currentTimeMillis()
     val bson = BSONDateTime(time)

--- a/bson/src/test/scala/Handlers.scala
+++ b/bson/src/test/scala/Handlers.scala
@@ -159,7 +159,7 @@ class Handlers extends org.specs2.mutable.Specification {
 
       result mustEqual BSONDocument("a" -> 1, "b" -> 2)
     }
-    
+
     "read primitives values" in {
       val input = BSONDocument("a" -> 1, "b" -> 2)
       val handler = implicitly[BSONReader[BSONDocument, Map[String, Int]]]
@@ -169,8 +169,8 @@ class Handlers extends org.specs2.mutable.Specification {
     }
 
     case class Foo(label: String, count: Int)
-    val fooWriter = BSONDocumentWriter[Foo] { foo => BSONDocument("label" -> foo.label, "count" -> foo.count) }
-    val fooReader = BSONDocumentReader[Foo] { document =>
+    implicit val fooWriter = BSONDocumentWriter[Foo] { foo => BSONDocument("label" -> foo.label, "count" -> foo.count) }
+    implicit val fooReader = BSONDocumentReader[Foo] { document =>
       val foo = for {
         label <- document.getAs[String]("label")
         count <- document.getAs[Int]("count")


### PR DESCRIPTION
- Keys are stored as string. It is possible to handle an another type if there is a handler that produces a string.
- Values can be primitives values or complex types (stored as documents)

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [ ] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
