### PR TITLE
Deprecate CollectionMetaCommands.rename

### DIFF
--- a/driver/src/main/scala/api/CollectionMetaCommands.scala
+++ b/driver/src/main/scala/api/CollectionMetaCommands.scala
@@ -112,6 +112,7 @@ trait CollectionMetaCommands { self: Collection =>
    *
    * @return a failure if the dropExisting option is false and the target collection already exists
    */
+  @deprecated(message = "Use `reactivemongo.api.DBMetaCommands.renameCollection on the admin database instead.", since = "0.12.4")
   def rename(to: String, dropExisting: Boolean = false)(implicit ec: ExecutionContext): Future[Unit] =
     Command.run(BSONSerializationPack).unboxed(self.db, RenameCollection(db.name + "." + name, db.name + "." + to, dropExisting), ReadPreference.primary)
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [x] Have you added tests for any changed functionality?

## Purpose

This PR deprecates the `rename` command on a collection.

## Background Context

The actual implementation of this command runs the command `RenameCollection` on the collection itself, but this only works on the admin database. It is better to use the `renameCollection` directly on the admin database as we can see in [AdminSpec.scala](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/driver/src/test/scala/AdminSpec.scala#L72).
