### PR TITLE
Adding ping command.

### DIFF
--- a/driver/src/main/scala/api/DBMetaCommands.scala
+++ b/driver/src/main/scala/api/DBMetaCommands.scala
@@ -78,7 +78,7 @@ trait DBMetaCommands { self: DB =>
    * Can only be executed if the this database reference is the `admin` one.
    *
    * @param db the name of the database where the collection exists with the `current` name
-   * @param current the current name of the collection, in the specified `db`
+   * @param from the current name of the collection, in the specified `db`
    * @param to the new name of this collection (inside the same `db`)
    * @param dropExisting If a collection of name `to` already exists, then drops that collection before renaming this one.
    *
@@ -130,9 +130,15 @@ trait DBMetaCommands { self: DB =>
   }
 
   /**
-   * Returns 1.0 when the server is responding to commands.
+   * Test if server responds to commands. The command will return `true` even if mongo is write-locked.
+   *
+   * @param readPreference Server to execute command against (default: `Nearest`).
+   *
+   * @return `true` if successful
    */
-  def ping(implicit ec: ExecutionContext): Future[Double] =
-    Command.run(BSONPingCommand.pack, FailoverStrategy())
-      .unboxed(self, BSONPingCommand.Ping(), ReadPreference.primary)
+  def ping(readPreference: ReadPreference = ReadPreference.nearest)(implicit ec: ExecutionContext): Future[Boolean] = {
+    Command.run(BSONPingCommand.pack, failoverStrategy)
+      .unboxed(self, BSONPingCommand.Ping(), readPreference)
+  }
 }
+

--- a/driver/src/main/scala/api/DBMetaCommands.scala
+++ b/driver/src/main/scala/api/DBMetaCommands.scala
@@ -28,7 +28,8 @@ trait DBMetaCommands { self: DB =>
     CommonImplicits,
     BSONDropDatabaseImplicits,
     BSONServerStatusImplicits,
-    BSONCreateUserCommand
+    BSONCreateUserCommand,
+    BSONPingCommand
   }
   import reactivemongo.api.commands.bson.BSONListCollectionNamesImplicits._
   import CommonImplicits._
@@ -127,4 +128,11 @@ trait DBMetaCommands { self: DB =>
       self, command, ReadPreference.primary
     ).map(_ => {})
   }
+
+  /**
+   * Returns 1.0 when the server is responding to commands.
+   */
+  def ping(implicit ec: ExecutionContext): Future[Double] =
+    Command.run(BSONPingCommand.pack, FailoverStrategy())
+      .unboxed(self, BSONPingCommand.Ping(), ReadPreference.primary)
 }

--- a/driver/src/main/scala/api/DBMetaCommands.scala
+++ b/driver/src/main/scala/api/DBMetaCommands.scala
@@ -141,4 +141,3 @@ trait DBMetaCommands { self: DB =>
       .apply(self, PingCommand, readPreference)
   }
 }
-

--- a/driver/src/main/scala/api/DBMetaCommands.scala
+++ b/driver/src/main/scala/api/DBMetaCommands.scala
@@ -133,6 +133,7 @@ trait DBMetaCommands { self: DB =>
 
   /**
    * Tests if the server, resolved according to the given read preference, responds to commands.
+   * (since MongoDB 3.0)
    *
    * @return true if successful (even if the server is write locked)
    */

--- a/driver/src/main/scala/api/commands/bson/instanceadministration.scala
+++ b/driver/src/main/scala/api/commands/bson/instanceadministration.scala
@@ -376,3 +376,18 @@ object BSONCreateUserCommand
     )
   }
 }
+
+object BSONPingCommand extends PingCommand[BSONSerializationPack.type] {
+  val pack = BSONSerializationPack
+
+  implicit object PingWriter extends BSONDocumentWriter[Ping] {
+    def write(ping: Ping): BSONDocument = BSONDocument("ping" -> ping.number)
+  }
+
+  implicit object PongReader extends DealingWithGenericCommandErrorsReader[Pong] {
+    def readResult(bson: BSONDocument): Pong =
+      Pong(bson.getAs[BSONNumberLike]("ok").map(_.toDouble).getOrElse(0))
+  }
+
+}
+

--- a/driver/src/main/scala/api/commands/bson/instanceadministration.scala
+++ b/driver/src/main/scala/api/commands/bson/instanceadministration.scala
@@ -386,7 +386,7 @@ object BSONPingCommand extends PingCommand[BSONSerializationPack.type] {
 
   implicit object PongReader extends DealingWithGenericCommandErrorsReader[Pong] {
     def readResult(bson: BSONDocument): Pong =
-      Pong(bson.getAs[BSONNumberLike]("ok").map(_.toDouble).getOrElse(0))
+      Pong(bson.getAs[BSONBooleanLike]("ok").exists(_.toBoolean))
   }
 
 }

--- a/driver/src/main/scala/api/commands/bson/instanceadministration.scala
+++ b/driver/src/main/scala/api/commands/bson/instanceadministration.scala
@@ -377,17 +377,14 @@ object BSONCreateUserCommand
   }
 }
 
-object BSONPingCommand extends PingCommand[BSONSerializationPack.type] {
-  val pack = BSONSerializationPack
-
-  implicit object PingWriter extends BSONDocumentWriter[Ping] {
-    def write(ping: Ping): BSONDocument = BSONDocument("ping" -> ping.number)
+object BSONPingCommandImplicits {
+  implicit object PingWriter extends BSONDocumentWriter[PingCommand.type] {
+    val command = BSONDocument("ping" -> 1.0)
+    def write(ping: PingCommand.type): BSONDocument = command
   }
 
-  implicit object PongReader extends DealingWithGenericCommandErrorsReader[Pong] {
-    def readResult(bson: BSONDocument): Pong =
-      Pong(bson.getAs[BSONBooleanLike]("ok").exists(_.toBoolean))
+  implicit object PingReader extends BSONDocumentReader[Boolean] {
+    def read(bson: BSONDocument): Boolean = bson.getAs[BSONBooleanLike]("ok").exists(_.toBoolean)
   }
-
 }
 

--- a/driver/src/main/scala/api/commands/bson/instanceadministration.scala
+++ b/driver/src/main/scala/api/commands/bson/instanceadministration.scala
@@ -383,7 +383,7 @@ object BSONPingCommandImplicits {
     def write(ping: PingCommand.type): BSONDocument = command
   }
 
-  implicit object PingReader extends BSONDocumentReader[Boolean] {
-    def read(bson: BSONDocument): Boolean = bson.getAs[BSONBooleanLike]("ok").exists(_.toBoolean)
+  implicit object PingReader extends DealingWithGenericCommandErrorsReader[Boolean] {
+    def readResult(bson: BSONDocument): Boolean = bson.getAs[BSONBooleanLike]("ok").exists(_.toBoolean)
   }
 }

--- a/driver/src/main/scala/api/commands/bson/instanceadministration.scala
+++ b/driver/src/main/scala/api/commands/bson/instanceadministration.scala
@@ -387,4 +387,3 @@ object BSONPingCommandImplicits {
     def read(bson: BSONDocument): Boolean = bson.getAs[BSONBooleanLike]("ok").exists(_.toBoolean)
   }
 }
-

--- a/driver/src/main/scala/api/commands/instanceadministration.scala
+++ b/driver/src/main/scala/api/commands/instanceadministration.scala
@@ -274,14 +274,5 @@ trait CreateUserCommand[P <: SerializationPack]
 /**
  * The [[https://docs.mongodb.com/manual/reference/command/ping/ ping]] command.
  */
-trait PingCommand[P <: SerializationPack] {
-
-  case class Pong(bool: Boolean) extends BoxedAnyVal[Boolean] {
-    def value: Boolean = bool
-  }
-
-  case class Ping(number: Double = 1.0) extends Command
-    with CommandWithPack[P]
-    with CommandWithResult[Pong]
-}
+case object PingCommand extends Command with CommandWithResult[Boolean]
 

--- a/driver/src/main/scala/api/commands/instanceadministration.scala
+++ b/driver/src/main/scala/api/commands/instanceadministration.scala
@@ -270,3 +270,18 @@ trait CreateUserCommand[P <: SerializationPack]
       with CommandWithResult[UnitBox.type]
 
 }
+
+/**
+ * The [[https://docs.mongodb.com/manual/reference/command/ping/ ping]] command.
+ */
+trait PingCommand[P <: SerializationPack] {
+
+  case class Pong(number: Double) extends BoxedAnyVal[Double] {
+    def value: Double = number
+  }
+
+  case class Ping(number: Double = 1.0) extends Command
+    with CommandWithPack[P]
+    with CommandWithResult[Pong]
+}
+

--- a/driver/src/main/scala/api/commands/instanceadministration.scala
+++ b/driver/src/main/scala/api/commands/instanceadministration.scala
@@ -276,8 +276,8 @@ trait CreateUserCommand[P <: SerializationPack]
  */
 trait PingCommand[P <: SerializationPack] {
 
-  case class Pong(number: Double) extends BoxedAnyVal[Double] {
-    def value: Double = number
+  case class Pong(bool: Boolean) extends BoxedAnyVal[Boolean] {
+    def value: Boolean = bool
   }
 
   case class Ping(number: Double = 1.0) extends Command

--- a/driver/src/test/scala/AdminSpec.scala
+++ b/driver/src/test/scala/AdminSpec.scala
@@ -233,10 +233,10 @@ class PingSpecification extends Specification {
 
   "respond 1.0" >> {
     "with the default connection" in { implicit ee: EE =>
-      connection.database("admin").flatMap(_.ping) must beEqualTo(1.0).await(0, timeout)
+      connection.database("admin").flatMap(_.ping()) must beTrue.await(0, timeout)
     }
     "with the slow connection" in { implicit ee: EE =>
-      slowConnection.database("admin").flatMap(_.ping) must beEqualTo(1.0).await(0, timeout)
+      slowConnection.database("admin").flatMap(_.ping()) must beTrue.await(0, timeout)
     }
   }
 }

--- a/driver/src/test/scala/AdminSpec.scala
+++ b/driver/src/test/scala/AdminSpec.scala
@@ -240,4 +240,3 @@ class PingSpecification extends Specification {
     }
   }
 }
-

--- a/driver/src/test/scala/AdminSpec.scala
+++ b/driver/src/test/scala/AdminSpec.scala
@@ -227,3 +227,17 @@ class ReplSetMaintenanceSpec extends Specification {
 
   }
 }
+
+class PingSpecification extends Specification {
+  "Ping Command" title
+
+  "respond 1.0" >> {
+    "with the default connection" in { implicit ee: EE =>
+      connection.database("admin").flatMap(_.ping) must beEqualTo(1.0).await(0, timeout)
+    }
+    "with the slow connection" in { implicit ee: EE =>
+      slowConnection.database("admin").flatMap(_.ping) must beEqualTo(1.0).await(0, timeout)
+    }
+  }
+}
+


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [x] Have you added tests for any changed functionality?

## Fixes

N/A

## Purpose

Provide an implementation of the mongo `ping` command. This is intended to be a lightweight test, similar to a `SELECT 1` used for SQL databases. 

This is a useful when performing a health test for an application. As an alternative to either `serverStatus` (database level) or `stats` (collection level).

## Background Context

The command is operating at the database level, not collection, within Mongo. I attempted to implement the command in a fashion that is similar to other administrative commands, like `serverStatus` or `drop`.

## References

I didn't see any discussion of the `ping` command when searching.