### PR TITLE
Changing type of index size values for stats command to Double.

### DIFF
--- a/driver/src/main/scala/api/commands/bson/instanceadministration.scala
+++ b/driver/src/main/scala/api/commands/bson/instanceadministration.scala
@@ -131,10 +131,10 @@ object BSONCollStatsImplicits {
       doc.getAs[BSONNumberLike]("paddingFactor").map(_.toDouble),
       doc.getAs[BSONNumberLike]("systemFlags").map(_.toInt),
       doc.getAs[BSONNumberLike]("userFlags").map(_.toInt),
-      doc.getAs[BSONNumberLike]("totalIndexSize").map(_.toDouble).get,
+      doc.getAs[Int]("totalIndexSize").getOrElse(-1),
       {
         val indexSizes = doc.getAs[BSONDocument]("indexSizes").get
-        (for (kv <- indexSizes.elements) yield kv.name -> kv.value.asInstanceOf[BSONDouble].value).toList
+        (for (kv <- indexSizes.elements) yield kv.name -> indexSizes.getAs[Int](kv.name).getOrElse(-1)).toList
       },
       doc.getAs[BSONBooleanLike]("capped").fold(false)(_.toBoolean),
       doc.getAs[BSONNumberLike]("max").map(_.toLong),

--- a/driver/src/main/scala/api/commands/bson/instanceadministration.scala
+++ b/driver/src/main/scala/api/commands/bson/instanceadministration.scala
@@ -131,10 +131,10 @@ object BSONCollStatsImplicits {
       doc.getAs[BSONNumberLike]("paddingFactor").map(_.toDouble),
       doc.getAs[BSONNumberLike]("systemFlags").map(_.toInt),
       doc.getAs[BSONNumberLike]("userFlags").map(_.toInt),
-      doc.getAs[BSONNumberLike]("totalIndexSize").map(_.toInt).get,
+      doc.getAs[BSONNumberLike]("totalIndexSize").map(_.toDouble).get,
       {
         val indexSizes = doc.getAs[BSONDocument]("indexSizes").get
-        (for (kv <- indexSizes.elements) yield kv._1 -> kv._2.asInstanceOf[BSONInteger].value).toList
+        (for (kv <- indexSizes.elements) yield kv.name -> kv.value.asInstanceOf[BSONDouble].value).toList
       },
       doc.getAs[BSONBooleanLike]("capped").fold(false)(_.toBoolean),
       doc.getAs[BSONNumberLike]("max").map(_.toLong),

--- a/driver/src/main/scala/api/commands/instanceadministration.scala
+++ b/driver/src/main/scala/api/commands/instanceadministration.scala
@@ -53,7 +53,8 @@ case class CollStats(scale: Option[Int] = None) extends CollectionCommand with C
  * @param paddingFactor Padding can speed up updates if documents grow (only for mmapv1 storage engine).
  * @param systemFlags System flags.
  * @param userFlags User flags.
- * @param indexSizes Size of specific indexes in bytes.
+ * @param totalIndexSize The total size in bytes (or in bytes / scale) of all indexes.
+ * @param sizePerIndex Size of specific indexes in bytes (or in bytes / scale).
  * @param capped States if this collection is capped.
  * @param max The maximum number of documents of this collection, if capped.
  * @param maxSize The maximum size in bytes (or in bytes / scale, if any) of this collection, if capped.
@@ -70,13 +71,13 @@ case class CollStatsResult(
     paddingFactor: Option[Double],
     systemFlags: Option[Int],
     userFlags: Option[Int],
-    totalIndexSize: Int,
-    sizePerIndex: List[(String, Int)],
+    totalIndexSize: Double,
+    sizePerIndex: List[(String, Double)],
     capped: Boolean,
     max: Option[Long],
     maxSize: Option[Double] = None
 ) {
-  @inline def indexSizes: Array[(String, Int)] = sizePerIndex.toArray
+  @inline def indexSizes: Array[(String, Double)] = sizePerIndex.toArray
 
   @deprecated(message = "Use [[copy]] with [[maxSize]]", since = "0.11.10")
   def copy(
@@ -91,8 +92,8 @@ case class CollStatsResult(
     paddingFactor: Option[Double] = this.paddingFactor,
     systemFlags: Option[Int] = this.systemFlags,
     userFlags: Option[Int] = this.userFlags,
-    totalIndexSize: Int = this.totalIndexSize,
-    indexSizes: Array[(String, Int)] = this.sizePerIndex.toArray,
+    totalIndexSize: Double = this.totalIndexSize,
+    indexSizes: Array[(String, Double)] = this.sizePerIndex.toArray,
     capped: Boolean = this.capped,
     max: Option[Long] = this.max
   ): CollStatsResult = CollStatsResult(

--- a/driver/src/main/scala/api/commands/instanceadministration.scala
+++ b/driver/src/main/scala/api/commands/instanceadministration.scala
@@ -53,8 +53,8 @@ case class CollStats(scale: Option[Int] = None) extends CollectionCommand with C
  * @param paddingFactor Padding can speed up updates if documents grow (only for mmapv1 storage engine).
  * @param systemFlags System flags.
  * @param userFlags User flags.
- * @param totalIndexSize The total size in bytes (or in bytes / scale) of all indexes.
- * @param sizePerIndex Size of specific indexes in bytes (or in bytes / scale).
+ * @param totalIndexSize The total size in bytes (or in bytes / scale) of all indexes. -1 if value exceeds Int.MaxValue
+ * @param sizePerIndex Size of specific indexes in bytes (or in bytes / scale). -1 if value exceeds Int.MaxValue
  * @param capped States if this collection is capped.
  * @param max The maximum number of documents of this collection, if capped.
  * @param maxSize The maximum size in bytes (or in bytes / scale, if any) of this collection, if capped.
@@ -71,13 +71,13 @@ case class CollStatsResult(
     paddingFactor: Option[Double],
     systemFlags: Option[Int],
     userFlags: Option[Int],
-    totalIndexSize: Double,
-    sizePerIndex: List[(String, Double)],
+    totalIndexSize: Int,
+    sizePerIndex: List[(String, Int)],
     capped: Boolean,
     max: Option[Long],
     maxSize: Option[Double] = None
 ) {
-  @inline def indexSizes: Array[(String, Double)] = sizePerIndex.toArray
+  @inline def indexSizes: Array[(String, Int)] = sizePerIndex.toArray
 
   @deprecated(message = "Use [[copy]] with [[maxSize]]", since = "0.11.10")
   def copy(
@@ -92,8 +92,8 @@ case class CollStatsResult(
     paddingFactor: Option[Double] = this.paddingFactor,
     systemFlags: Option[Int] = this.systemFlags,
     userFlags: Option[Int] = this.userFlags,
-    totalIndexSize: Double = this.totalIndexSize,
-    indexSizes: Array[(String, Double)] = this.sizePerIndex.toArray,
+    totalIndexSize: Int = this.totalIndexSize,
+    indexSizes: Array[(String, Int)] = this.sizePerIndex.toArray,
     capped: Boolean = this.capped,
     max: Option[Long] = this.max
   ): CollStatsResult = CollStatsResult(


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [x] Have you added tests for any changed functionality?

## Fixes

Index sizes can be larger than an `Int` can support. The documentation in mongo does not make clear the maximum value, only that it is a "number". 

https://docs.mongodb.com/manual/reference/command/collStats/#example

https://docs.mongodb.com/manual/reference/command/collStats/#collStats.totalIndexSize

## Purpose

This changes the types to `Double` to correspond to the other size values returned by the command.

## Background Context

This bug was discovered after adding several indices to an existing collection. The `stats()` command began returning this error:
```reactivemongo.bson.BSONDouble cannot be cast to reactivemongo.bson.BSONInteger : Error```

These were the values returned by `stats()`:
```javascript
{
                "sharded" : false,
                "primary" : "xxxx",
                "ns" : "yyyy",
                "count" : 2767914,
                "size" : 2517842272,
                "avgObjSize" : 909,
                "numExtents" : 22,
                "storageSize" : 3918798848,
                "lastExtentSize" : 1021497344,
                "paddingFactor" : 1,
                "paddingFactorNote" : "paddingFactor is unused and unmaintained in 3.0. It remains hard coded to 1.0 for compatibility only.",
                "userFlags" : 1,
                "capped" : false,
                "nindexes" : 5,
                "totalIndexSize" : 2659693680,
                "indexSizes" : {
                                "_id_" : 97400688,
                                "secureDistinctKey_1_secureId_1_observationDate_-1_updateDate_-1" : 1146806640,
                                "secureId_1_observationDate_-1_updateDate_-1" : 509430208,
                                "secureId_1_userId_1" : 612112592,
                                "userId_1_observationDate_-1_createDate_-1" : 293943552
                },
                "ok" : 1
}
```
The `totalIndexSize` was larger than an `Int` can support. I presume the same could occur for any single index as well.

## References

ReactiveMongo/ReactiveMongo#448 added `maxSize` and also matched type to `Double`