### PR TITLE
New annotation to flatten sub-handler when using the BSON macros

### DIFF
--- a/macros/src/main/scala-2.10/MacroImpl.scala
+++ b/macros/src/main/scala-2.10/MacroImpl.scala
@@ -2,7 +2,7 @@ package reactivemongo.bson
 
 import scala.collection.immutable.Set
 
-import reactivemongo.bson.Macros.Annotations.{ Ignore, Key }
+import reactivemongo.bson.Macros.Annotations.{ Flatten, Ignore, Key }
 import reactivemongo.bson.Macros.Options.SaveSimpleName
 
 import scala.reflect.macros.Context
@@ -61,13 +61,21 @@ private object MacroImpl {
     protected def A: Type
     protected def Opts: Type
 
+    type Reader[A] = BSONReader[_ <: BSONValue, A]
+    type Writer[A] = BSONWriter[A, _ <: BSONValue]
+
     private val writerType: Type = typeOf[Writer[_]].typeConstructor
+    private val docWriterType: Type =
+      typeOf[BSONDocumentWriter[_]].typeConstructor
+
     private val readerType: Type = typeOf[Reader[_]].typeConstructor
+    private val docReaderType: Type =
+      typeOf[BSONDocumentReader[_]].typeConstructor
 
     lazy val readBody: c.Expr[A] = {
-      val reader = unionTypes map { types =>
+      val reader = unionTypes.map { types =>
         val resolve = resolver(Map.empty, "Reader")(readerType)
-        val cases = types map { typ =>
+        val cases = types.map { typ =>
           val pattern = if (hasOption[SaveSimpleName])
             Literal(Constant(typ.typeSymbol.name.decodedName.toString))
           else
@@ -96,9 +104,9 @@ private object MacroImpl {
     }
 
     lazy val writeBody: c.Expr[BSONDocument] = {
-      val writer = unionTypes map { types =>
+      val writer = unionTypes.map { types =>
         val resolve = resolver(Map.empty, "Writer")(writerType)
-        val cases = types map { typ =>
+        val cases = types.map { typ =>
           val n = c.fresh("v")
           val id = Ident(n)
 
@@ -187,26 +195,38 @@ private object MacroImpl {
         }
         val opt = optionTypeParameter(sig)
         val typ = opt getOrElse sig
-        val (reader, _) = resolve(sig)
+        val (reader, _) = resolve(typ)
         val pname = paramName(param)
 
         if (reader.isEmpty) {
-          c.abort(c.enclosingPosition, s"Implicit not found for '$pname': ${classOf[Reader[_]].getName}[_, $sig]")
+          c.abort(c.enclosingPosition, s"Implicit not found for '$pname': ${classOf[Reader[_]].getName}[_, $typ]")
         }
 
-        opt match {
-          case Some(_) =>
+        if (param.annotations.exists(_.tpe =:= typeOf[Flatten]) &&
+          reader.tpe <:< appliedType(docReaderType, List(typ))) {
+
+          if (reader.toString == "forwardReader") {
+            c.abort(
+              c.enclosingPosition,
+              s"Cannot flatten reader for '$pname': recursive type")
+          }
+
+          Apply( // ${reader}.read(document)
+            Select(reader, "read"), List(Ident("document")))
+        } else opt match {
+          case Some(_) => // document.getAs[$typ]($pname)($reader)
             Apply(Apply(
               TypeApply(
                 Select(Ident("document"), "getAs"),
                 List(TypeTree(typ))),
               List(Literal(Constant(pname)))), List(reader))
 
-          case _ => Select(Apply(Apply(
-            TypeApply(
-              Select(Ident("document"), "getAsTry"),
-              List(TypeTree(typ))),
-            List(Literal(Constant(pname)))), List(reader)), "get")
+          case _ => // document.getAsTry[$typ]($pname)($reader).get
+            Select(Apply(Apply(
+              TypeApply(
+                Select(Ident("document"), "getAsTry"),
+                List(TypeTree(typ))),
+              List(Literal(Constant(pname)))), List(reader)), "get")
         }
       }
 
@@ -257,65 +277,117 @@ private object MacroImpl {
         case (sym, ty) => sym.fullName -> ty
       }.toMap
       val resolve = resolver(boundTypes, "Writer")(writerType)
-      val tuple = Ident(newTermName("tuple"))
+      lazy val tupleName = newTermName("tuple")
 
       val (optional, required) =
         constructorParams.zipWithIndex.zip(types).filterNot {
           case ((sym, _), _) => ignoreField(sym)
         }.partition(t => isOptionalType(t._2))
 
-      val values = required map {
-        case ((param, i), sig) =>
-          val (writer, _) = resolve(sig)
-          val pname = paramName(param)
+      def resolveWriter(pname: String, tpe: Type) = {
+        val (writer, _) = resolve(tpe)
 
-          if (writer.isEmpty) {
-            c.abort(c.enclosingPosition, s"Implicit not found for '$pname': ${classOf[Writer[_]].getName}[$sig, _]")
-          }
+        if (writer.isEmpty) {
+          c.abort(c.enclosingPosition, s"Implicit not found for '$pname': ${classOf[Writer[_]].getName}[$tpe, _]")
+        }
 
-          val tuple_i = if (types.length == 1) tuple else Select(tuple, "_" + (i + 1))
-          val bs_value = c.Expr[BSONValue](Apply(Select(writer, "write"), List(tuple_i)))
-          val name = c.literal(pname)
-          reify((name.splice, bs_value.splice): (String, BSONValue)).tree
+        writer
       }
 
-      val appends = optional map {
+      val tupleElement: Int => Tree = {
+        val tuple = Ident(tupleName)
+
+        if (types.length == 1) { _: Int => tuple }
+        else { i: Int => Select(tuple, "_" + (i + 1)) }
+      }
+
+      // TODO: buf newTermName
+      val bufName = newTermName("buf")
+
+      // buf += ${pname} -> ${bsv}
+      def append[V <: BSONValue](pname: String, bsv: c.Expr[V]): Tree =
+        Apply(Select(Ident(bufName), "$plus$eq"), List(reify(
+          (c.literal(pname).splice, bsv.splice)).tree))
+
+      // buf ++= ${bsd}.elements
+      def appendFields(bsd: c.Expr[BSONDocument]): Tree =
+        Apply(
+          Select(Ident(bufName), "$plus$plus$eq"),
+          List(reify(bsd.splice.elements).tree))
+
+      def mustFlatten(
+        param: Symbol,
+        pname: String,
+        sig: Type,
+        writer: Tree): Boolean = {
+        if (param.annotations.exists(_.tpe =:= typeOf[Flatten]) &&
+          writer.tpe <:< appliedType(docWriterType, List(sig))) {
+
+          if (writer.toString == "forwardWriter") {
+            c.abort(
+              c.enclosingPosition,
+              s"Cannot flatten writer for '$pname': recursive type")
+          }
+
+          true
+        } else false
+      }
+
+      val values = required.map {
+        case ((param, i), sig) =>
+          val pname = paramName(param)
+          val writer = resolveWriter(pname, sig)
+
+          if (mustFlatten(param, pname, sig, writer)) {
+            val bsd = c.Expr[BSONDocument](
+              Apply(Select(writer, "write"), List(tupleElement(i))))
+
+            appendFields(bsd)
+          } else {
+            val bsv = c.Expr[BSONValue](
+              Apply(Select(writer, "write"), List(tupleElement(i))))
+
+            append(pname, bsv)
+          }
+      }
+
+      val extra = optional.flatMap {
         case ((param, i), optType) =>
           val sig = optionTypeParameter(optType).get
-          val (writer, _) = resolve(sig)
           val pname = paramName(param)
+          val writer = resolveWriter(pname, sig)
 
-          if (writer.isEmpty) {
-            c.abort(c.enclosingPosition, s"Implicit not found for '$pname': ${classOf[Writer[_]].getName}[$sig, _]")
-          }
+          val vterm = newTermName("v")
+          val bsv = c.Expr[BSONValue]( // writer.write(${vterm})
+            Apply(Select(writer, "write"), List(Ident(vterm))))
 
-          val tuple_i = if (types.length == 1) tuple else Select(tuple, "_" + (i + 1))
-          val bs_value = c.Expr[BSONValue](Apply(Select(writer, "write"), List(Select(tuple_i, "get"))))
-          val name = c.literal(pname)
-          If(
-            Select(tuple_i, "isDefined"),
-            Apply(Select(Ident("buf"), "$plus$colon$eq"), List(reify((name.splice, bs_value.splice)).tree)),
-            EmptyTree)
+          val ap = append(pname, bsv)
+
+          val z = Apply(Select(tupleElement(i), newTermName("foreach")), List(
+            Function(List(
+              ValDef(Modifiers(c.universe.Flag.PARAM), vterm,
+                TypeTree(sig), EmptyTree)), ap)))
+
+          List(z)
       }
 
-      val mkBSONdoc = Apply(
-        bsonDocPath,
-        values ++ classNameTree(tpe).map(_.tree))
-
-      val writer = {
-        if (optional.isEmpty) List(mkBSONdoc)
-        else List(
-          ValDef(Modifiers(), newTermName("bson"), TypeTree(), mkBSONdoc),
-          c.parse("var buf = scala.collection.immutable.Stream[(String,reactivemongo.bson.BSONValue)]()")) ++ appends :+ c.parse("bson.merge(reactivemongo.bson.BSONDocument(buf))")
+      // List[Tree] corresponding to fields appended to the buffer/builder
+      val fields = values ++ extra ++ classNameTree(tpe).map { cn =>
+        Apply(Select(Ident(bufName), "$plus$eq"), List(cn.tree))
       }
 
-      val unapplyTree = Select(Ident(companion(tpe).name.toString), "unapply")
-      val invokeUnapply = Select(Apply(unapplyTree, List(id)), "get")
-      val tupleDef = ValDef(Modifiers(), newTermName("tuple"), TypeTree(), invokeUnapply)
+      val writer =
+        c.parse(s"val ${bufName} = scala.collection.immutable.Stream.newBuilder[reactivemongo.bson.BSONElement]") +: (fields :+ c.parse("reactivemongo.bson.BSONDocument(buf.result())"))
 
-      if (values.length + appends.length > 0) {
+      if (constructorParams.isEmpty) { // no class parameter to unapply
+        Block(writer: _*)
+      } else {
+        val unapplyTree = Select(Ident(companion(tpe).name.toString), "unapply")
+        val invokeUnapply = Select(Apply(unapplyTree, List(id)), "get")
+        val tupleDef = ValDef(Modifiers(), tupleName, TypeTree(), invokeUnapply)
+
         Block((tupleDef :: writer): _*)
-      } else writer.head
+      }
     }
 
     private def classNameTree(tpe: Type): Option[c.Expr[(String, BSONString)]] = {
@@ -327,7 +399,7 @@ private object MacroImpl {
           c.literal(tpe.typeSymbol.name.decodedName.toString)
         } else c.literal(tpe.typeSymbol.fullName)
 
-        reify("className", BSONStringHandler.write(name.splice))
+        reify("className" -> BSONStringHandler.write(name.splice))
       }
       else None
     }
@@ -367,7 +439,8 @@ private object MacroImpl {
 
         case _ => None
       }
-      tree map { t => parseUnionTree(List(t), Nil) }
+
+      tree.map { t => parseUnionTree(List(t), Nil) }
     }
 
     private def directKnownSubclasses: Option[List[Type]] = {
@@ -571,9 +644,6 @@ private object MacroImpl {
         }
       }.headOption
     } yield apply -> unapply
-
-    type Reader[A] = BSONReader[_ <: BSONValue, A]
-    type Writer[A] = BSONWriter[A, _ <: BSONValue]
 
     private def isSingleton(t: Type): Boolean = t <:< typeOf[Singleton]
 

--- a/macros/src/main/scala-2.11/MacroImpl.scala
+++ b/macros/src/main/scala-2.11/MacroImpl.scala
@@ -1,6 +1,6 @@
 package reactivemongo.bson
 
-import reactivemongo.bson.Macros.Annotations.{ Ignore, Key }
+import reactivemongo.bson.Macros.Annotations.{ Flatten, Ignore, Key }
 import reactivemongo.bson.Macros.Options.SaveSimpleName
 
 import scala.collection.immutable.Set
@@ -62,12 +62,17 @@ private object MacroImpl {
     protected def Opts: Type
 
     private val writerType: Type = typeOf[Writer[_]].typeConstructor
+    private val docWriterType: Type =
+      typeOf[BSONDocumentWriter[_]].typeConstructor
+
     private val readerType: Type = typeOf[Reader[_]].typeConstructor
+    private val docReaderType: Type =
+      typeOf[BSONDocumentReader[_]].typeConstructor
 
     lazy val readBody: c.Expr[A] = {
       val reader = unionTypes.map { types =>
         val resolve = resolver(Map.empty, "Reader")(readerType)
-        val cases = types map { typ =>
+        val cases = types.map { typ =>
           val pattern = if (hasOption[SaveSimpleName])
             Literal(Constant(typ.typeSymbol.name.decodedName.toString))
           else
@@ -140,8 +145,8 @@ private object MacroImpl {
         case TypeRef(_, sym, _) => sym
         case _                  => c.abort(c.enclosingPosition, s"Something weird is going on with '$tpe'. Should be a singleton but can't parse it")
       }
-      val name = TermName(sym.name.toString) //this is ugly but quite stable compared to other attempts
-      Ident(name)
+
+      Ident(TermName(sym.name.toString))
     }
 
     private def readBodyConstructClass(implicit tpe: Type) = {
@@ -157,23 +162,33 @@ private object MacroImpl {
       }.toMap
       val resolve = resolver(boundTypes, "Reader")(readerType)
 
-      val values = constructor.paramLists.head.map { param =>
-        val t = param.typeSignature
-        val sig = boundTypes.getOrElse(t.typeSymbol.fullName, t)
-        val opt = optionTypeParameter(sig)
-        //val typ = opt getOrElse sig
-        val (reader, _) = resolve(sig)
-        val pname = paramName(param)
+      val values = constructor.paramLists.
+        headOption.toSeq.flatten.map { param =>
+          val t = param.typeSignature
+          val sig = boundTypes.getOrElse(t.typeSymbol.fullName, t)
+          val opt = optionTypeParameter(sig)
+          val (reader, _) = resolve(sig)
+          val pname = paramName(param)
 
-        if (reader.isEmpty) {
-          c.abort(c.enclosingPosition, s"Implicit not found for '$pname': ${classOf[Reader[_]].getName}[_, $sig]")
-        }
+          if (reader.isEmpty) {
+            c.abort(c.enclosingPosition, s"Implicit not found for '$pname': ${classOf[Reader[_]].getName}[_, $sig]")
+          }
 
-        opt match {
-          case Some(_) => q"document.getAs($pname)($reader)"
-          case _       => q"document.getAsTry($pname)($reader).get"
+          if (param.annotations.exists(_.tree.tpe =:= typeOf[Flatten]) &&
+            reader.tpe <:< appliedType(docReaderType, List(sig))) {
+
+            if (reader.toString == "forwardReader") {
+              c.abort(
+                c.enclosingPosition,
+                s"Cannot flatten reader for '$pname': recursive type")
+            }
+
+            q"${reader}.read(document)"
+          } else opt match {
+            case Some(_) => q"document.getAs($pname)($reader)"
+            case _       => q"document.getAsTry($pname)($reader).get"
+          }
         }
-      }
 
       q"${Ident(companion.name)}.apply(..$values)"
     }
@@ -202,7 +217,7 @@ private object MacroImpl {
       else writeBodyConstructClass(id, tpe)
 
     private def writeBodyConstructSingleton(tpe: Type): Tree = (
-      classNameTree(tpe) map { nameE =>
+      classNameTree(tpe).map { nameE =>
         reify { BSONDocument(Seq((nameE.splice))) }
       } getOrElse reify { BSONDocument.empty }).tree
 
@@ -227,46 +242,48 @@ private object MacroImpl {
           case ((sym, _), _) => ignoreField(sym)
         }.partition(t => isOptionalType(t._2))
 
-      val values = required map {
-        case ((param, i), sig) =>
-          val (writer, _) = resolve(sig)
-          val pname = paramName(param)
+      def resolveWriter(pname: String, tpe: Type) = {
+        val (writer, _) = resolve(tpe)
 
-          if (writer.isEmpty) {
-            c.abort(c.enclosingPosition, s"Implicit not found for '$pname': ${classOf[Writer[_]].getName}[${sig.typeSymbol.name}, _]")
-          }
+        if (writer.isEmpty) {
+          c.abort(c.enclosingPosition, s"Implicit not found for '$pname': ${classOf[Writer[_]].getName}[$tpe, _]")
+        }
 
-          val tuple_i = {
-            if (types.length == 1) tuple
-            else Select(tuple, TermName("_" + (i + 1)))
-          }
-          val bs_value = c.Expr[BSONValue](q"$writer.write(${tuple_i})")
-          val name = c.Expr[String](q"$pname")
-          reify((name.splice, bs_value.splice): (String, BSONValue)).tree
+        writer
       }
 
-      val appends = optional map {
-        case ((param, i), optType) =>
-          val sig = optionTypeParameter(optType).get
-          val (writer, _) = resolve(sig)
+      val tupleElement: Int => Tree = {
+        if (types.length == 1) { _: Int => tuple }
+        else { i: Int => Select(tuple, "_" + (i + 1)) }
+      }
+
+      val values = required.flatMap {
+        case ((param, i), sig) =>
           val pname = paramName(param)
+          val writer = resolveWriter(pname, sig)
 
-          if (writer.isEmpty) {
-            c.abort(c.enclosingPosition, s"Implicit not found for '$pname': ${classOf[Writer[_]].getName}[${sig.typeSymbol.name}, _]")
-          }
-
-          val tuple_i = {
-            if (types.length == 1) tuple
-            else Select(tuple, TermName("_" + (i + 1)))
-          }
-          val bs_value = c.Expr[BSONValue](q"$writer.write($tuple_i.get)")
+          val bs_value = c.Expr[BSONValue](q"$writer.write(${tupleElement(i)})")
           val name = c.Expr[String](q"$pname")
 
-          If(
-            Select(tuple_i, TermName("isDefined")),
-            Apply(Select(Ident(TermName("buf")), TermName("$plus$colon$eq")), List(reify((name.splice, bs_value.splice)).tree)),
-            EmptyTree)
+          List(reify((name.splice, bs_value.splice): (String, BSONValue)).tree)
+      }
 
+      val appends = optional.flatMap {
+        case ((param, i), optType) =>
+          val sig = optionTypeParameter(optType).get
+          val pname = paramName(param)
+          val writer = resolveWriter(pname, sig)
+
+          val name = c.Expr[String](q"$pname")
+
+          val vterm = newTermName("v")
+          val bsv = c.Expr[BSONValue](q"$writer.write($vterm)")
+          val vp = ValDef(
+            Modifiers(c.universe.Flag.PARAM),
+            vterm, TypeTree(sig), EmptyTree) // ${v} =>
+          val ap = q"${reify((name.splice, bsv.splice)).tree}"
+
+          List(q"${tupleElement(i)}.foreach { $vp => buf += $ap }")
       }
 
       val mkBSONdoc = Apply(
@@ -276,7 +293,7 @@ private object MacroImpl {
         if (optional.isEmpty) List(mkBSONdoc)
         else List(
           q"val bson = $mkBSONdoc",
-          q"var buf = scala.collection.immutable.Stream[(String,reactivemongo.bson.BSONValue)]()") ++ appends :+ q"bson.merge(reactivemongo.bson.BSONDocument(buf))"
+          q"val buf = scala.collection.immutable.Stream.newBuilder[(String,reactivemongo.bson.BSONValue)]") ++ appends :+ q"bson.merge(reactivemongo.bson.BSONDocument(buf.result()))"
       }
 
       val unapplyTree = Select(Ident(companion(tpe).name), TermName("unapply"))

--- a/macros/src/main/scala-2.11/MacroImpl.scala
+++ b/macros/src/main/scala-2.11/MacroImpl.scala
@@ -235,7 +235,7 @@ private object MacroImpl {
         case (sym, ty) => sym.fullName -> ty
       }.toMap
       val resolve = resolver(boundTypes, "Writer")(writerType)
-      val tuple = Ident(TermName("tuple"))
+      lazy val tupleName = TermName("tuple")
 
       val (optional, required) =
         constructorParams.zipWithIndex.zip(types).filterNot {
@@ -253,57 +253,88 @@ private object MacroImpl {
       }
 
       val tupleElement: Int => Tree = {
+        val tuple = Ident(tupleName)
+
         if (types.length == 1) { _: Int => tuple }
         else { i: Int => Select(tuple, "_" + (i + 1)) }
       }
 
-      val values = required.flatMap {
+      val bufName = TermName("buf")
+
+      def mustFlatten(
+        param: Symbol,
+        pname: String,
+        sig: Type,
+        writer: Tree): Boolean = {
+        if (param.annotations.exists(_.tpe =:= typeOf[Flatten]) &&
+          writer.tpe <:< appliedType(docWriterType, List(sig))) {
+
+          if (writer.toString == "forwardWriter") {
+            c.abort(
+              c.enclosingPosition,
+              s"Cannot flatten writer for '$pname': recursive type")
+          }
+
+          true
+        } else false
+      }
+
+      val values = required.map {
         case ((param, i), sig) =>
           val pname = paramName(param)
           val writer = resolveWriter(pname, sig)
 
-          val bs_value = c.Expr[BSONValue](q"$writer.write(${tupleElement(i)})")
-          val name = c.Expr[String](q"$pname")
-
-          List(reify((name.splice, bs_value.splice): (String, BSONValue)).tree)
+          if (mustFlatten(param, pname, sig, writer)) {
+            q"$bufName ++= $writer.write(${tupleElement(i)}).elements"
+          } else {
+            q"$bufName += $pname -> $writer.write(${tupleElement(i)})"
+          }
       }
 
-      val appends = optional.flatMap {
+      val extra = optional.map {
         case ((param, i), optType) =>
           val sig = optionTypeParameter(optType).get
           val pname = paramName(param)
           val writer = resolveWriter(pname, sig)
 
-          val name = c.Expr[String](q"$pname")
+          if (mustFlatten(param, pname, sig, writer)) {
+            q"$bufName ++= $writer.write(${tupleElement(i)}).elements"
+          } else {
+            val name = c.Expr[String](q"$pname")
 
-          val vterm = newTermName("v")
-          val bsv = c.Expr[BSONValue](q"$writer.write($vterm)")
-          val vp = ValDef(
-            Modifiers(c.universe.Flag.PARAM),
-            vterm, TypeTree(sig), EmptyTree) // ${v} =>
-          val ap = q"${reify((name.splice, bsv.splice)).tree}"
+            val vterm = TermName("v")
+            val bsv = c.Expr[BSONValue](q"$writer.write($vterm)")
+            val vp = ValDef(
+              Modifiers(c.universe.Flag.PARAM),
+              vterm, TypeTree(sig), EmptyTree) // ${v} =>
+            val field = reify((name.splice, bsv.splice)).tree
 
-          List(q"${tupleElement(i)}.foreach { $vp => buf += $ap }")
+            q"${tupleElement(i)}.foreach { $vp => $bufName += $field }"
+          }
       }
 
-      val mkBSONdoc = Apply(
-        bsonDocPath, values ++ classNameTree(tpe).map(_.tree))
-
-      val writer = {
-        if (optional.isEmpty) List(mkBSONdoc)
-        else List(
-          q"val bson = $mkBSONdoc",
-          q"val buf = scala.collection.immutable.Stream.newBuilder[(String,reactivemongo.bson.BSONValue)]") ++ appends :+ q"bson.merge(reactivemongo.bson.BSONDocument(buf.result()))"
+      // List[Tree] corresponding to fields appended to the buffer/builder
+      val fields = values ++ extra ++ classNameTree(tpe).map { cn =>
+        q"$bufName += $cn"
       }
 
-      val unapplyTree = Select(Ident(companion(tpe).name), TermName("unapply"))
-      val invokeUnapply = Select(Apply(unapplyTree, List(id)), TermName("get"))
-      val tupleDef = q"val tuple = $invokeUnapply"
+      val writer = q"val ${bufName} = scala.collection.immutable.Stream.newBuilder[reactivemongo.bson.BSONElement]" +: (fields :+ q"reactivemongo.bson.BSONDocument(${bufName}.result())")
 
-      if (values.length + appends.length > 0) {
-        val trees = tupleDef :: writer
-        q"{..$trees}"
-      } else writer.head
+      if (values.isEmpty && extra.isEmpty) {
+        q"{..$writer}"
+      } else {
+        // Extract/unapply the class instance as ${tupleDef}
+
+        val unapplyTree = Select(Ident(
+          companion(tpe).name), TermName("unapply"))
+
+        val invokeUnapply = Select(Apply(
+          unapplyTree, List(id)), TermName("get"))
+
+        val tupleDef = q"val tuple = $invokeUnapply"
+
+        q"{..${tupleDef :: writer}}"
+      }
     }
 
     private def classNameTree(tpe: c.Type): Option[c.Expr[(String, BSONString)]] = {
@@ -436,9 +467,6 @@ private object MacroImpl {
 
     private def isOptionalType(implicit A: c.Type): Boolean =
       (c.typeOf[Option[_]].typeConstructor == A.typeConstructor)
-
-    private def bsonDocPath: c.universe.Select = Select(Select(Ident(
-      TermName("reactivemongo")), TermName("bson")), TermName("BSONDocument"))
 
     private def paramName(param: c.Symbol): String = {
       param.annotations.collect {

--- a/macros/src/main/scala-2.11/MacroImpl.scala
+++ b/macros/src/main/scala-2.11/MacroImpl.scala
@@ -174,13 +174,15 @@ private object MacroImpl {
             c.abort(c.enclosingPosition, s"Implicit not found for '$pname': ${classOf[Reader[_]].getName}[_, $sig]")
           }
 
-          if (param.annotations.exists(_.tree.tpe =:= typeOf[Flatten]) &&
-            reader.tpe <:< appliedType(docReaderType, List(sig))) {
-
+          if (param.annotations.exists(_.tree.tpe =:= typeOf[Flatten])) {
             if (reader.toString == "forwardReader") {
               c.abort(
                 c.enclosingPosition,
                 s"Cannot flatten reader for '$pname': recursive type")
+            }
+
+            if (!(reader.tpe <:< appliedType(docReaderType, List(sig)))) {
+              c.abort(c.enclosingPosition, s"Cannot flatten reader '$reader': doesn't conform BSONDocumentReader")
             }
 
             q"${reader}.read(document)"
@@ -266,13 +268,16 @@ private object MacroImpl {
         pname: String,
         sig: Type,
         writer: Tree): Boolean = {
-        if (param.annotations.exists(_.tpe =:= typeOf[Flatten]) &&
-          writer.tpe <:< appliedType(docWriterType, List(sig))) {
+        if (param.annotations.exists(_.tpe =:= typeOf[Flatten])) {
 
           if (writer.toString == "forwardWriter") {
             c.abort(
               c.enclosingPosition,
               s"Cannot flatten writer for '$pname': recursive type")
+          }
+
+          if (!(writer.tpe <:< appliedType(docWriterType, List(sig)))) {
+            c.abort(c.enclosingPosition, s"Cannot flatten writer '$writer': doesn't conform BSONDocumentWriter")
           }
 
           true
@@ -296,21 +301,15 @@ private object MacroImpl {
           val sig = optionTypeParameter(optType).get
           val pname = paramName(param)
           val writer = resolveWriter(pname, sig)
+          val name = c.Expr[String](q"$pname")
+          val vterm = TermName("v")
+          val bsv = c.Expr[BSONValue](q"$writer.write($vterm)")
+          val vp = ValDef(
+            Modifiers(c.universe.Flag.PARAM),
+            vterm, TypeTree(sig), EmptyTree) // ${v} =>
+          val field = reify((name.splice, bsv.splice)).tree
 
-          if (mustFlatten(param, pname, sig, writer)) {
-            q"$bufName ++= $writer.write(${tupleElement(i)}).elements"
-          } else {
-            val name = c.Expr[String](q"$pname")
-
-            val vterm = TermName("v")
-            val bsv = c.Expr[BSONValue](q"$writer.write($vterm)")
-            val vp = ValDef(
-              Modifiers(c.universe.Flag.PARAM),
-              vterm, TypeTree(sig), EmptyTree) // ${v} =>
-            val field = reify((name.splice, bsv.splice)).tree
-
-            q"${tupleElement(i)}.foreach { $vp => $bufName += $field }"
-          }
+          q"${tupleElement(i)}.foreach { $vp => $bufName += $field }"
       }
 
       // List[Tree] corresponding to fields appended to the buffer/builder

--- a/macros/src/main/scala/Macros.scala
+++ b/macros/src/main/scala/Macros.scala
@@ -150,6 +150,29 @@ object Macros {
     /** Ignores a field */
     @meta.param
     case class Ignore() extends StaticAnnotation
+
+    /**
+     * Indicates that if a property is represented as a document itself,
+     * the document fields are directly included in top document,
+     * rather than nesting it.
+     *
+     * {{{
+     * case class Range(start: Int, end: Int)
+     *
+     * case class LabelledRange(
+     *   name: String,
+     *   @Flatten range: Range)
+     *
+     * // Flattened
+     * BSONDocument("name" -> "foo", "start" -> 0, "end" -> 1)
+     *
+     * // Rather than:
+     * // BSONDocument("name" -> "foo", "range" -> BSONDocument(
+     * //   "start" -> 0, "end" -> 1))
+     * }}}
+     */
+    @meta.param
+    case class Flatten() extends StaticAnnotation
   }
 
   /** Only for internal purposes */

--- a/macros/src/test/scala/MacroSpec.scala
+++ b/macros/src/test/scala/MacroSpec.scala
@@ -272,6 +272,7 @@ class MacroSpec extends org.specs2.mutable.Specification {
     "support automatic implementations search with nested traits with simple name" in {
       import Macros.Options._
       import InheritanceModule._
+
       implicit val format = Macros.handlerOpts[T, SimpleAllImplementations]
 
       format.write(A()).getAs[String]("className") must beSome("A")
@@ -324,6 +325,12 @@ class MacroSpec extends org.specs2.mutable.Specification {
         h.write(Bar("bar2", Some(bar1))) must_== BSONDocument(
           "name" -> "bar2", "next" -> doc1)
       }
+    }
+
+    "support @Flatten annotation" in {
+      roundtrip(
+        LabelledRange("range1", Range(start = 2, end = 5)),
+        Macros.handler[LabelledRange])
     }
 
     "handle case class with implicits" >> {
@@ -394,6 +401,14 @@ class MacroSpec extends org.specs2.mutable.Specification {
           aka("bar2") must_== Bar("bar2", Some(bar1))
       }
     }
+
+    "be generated with @Flatten annotation" in {
+      val r = Macros.reader[LabelledRange]
+      val doc = BSONDocument("name" -> "range1", "start" -> 2, "end" -> 5)
+      val lr = LabelledRange("range1", Range(start = 2, end = 5))
+
+      r.read(doc) must_== lr
+    }
   }
 
   "Writer" should {
@@ -416,6 +431,14 @@ class MacroSpec extends org.specs2.mutable.Specification {
           "name" -> "bar2", "next" -> doc1)
       }
     }
+
+    "be generated with @Flatten annotation" in {
+      val w = Macros.writer[LabelledRange]
+      val lr = LabelledRange("range2", Range(start = 1, end = 3))
+      val doc = BSONDocument("name" -> "range2", "start" -> 1, "end" -> 3)
+
+      w.write(lr) must_== doc
+    } // TODO: Test Flatten with a property Option[T : BSONDocumentWriter] ?
   }
 
   // ---

--- a/macros/src/test/scala/MacroSpec.scala
+++ b/macros/src/test/scala/MacroSpec.scala
@@ -328,6 +328,9 @@ class MacroSpec extends org.specs2.mutable.Specification {
     }
 
     "support @Flatten annotation" in {
+      shapeless.test.illTyped("Macros.handler[InvalidRecursive]")
+      shapeless.test.illTyped("Macros.handler[InvalidNonDoc]")
+
       roundtrip(
         LabelledRange("range1", Range(start = 2, end = 5)),
         Macros.handler[LabelledRange])
@@ -403,6 +406,9 @@ class MacroSpec extends org.specs2.mutable.Specification {
     }
 
     "be generated with @Flatten annotation" in {
+      shapeless.test.illTyped("Macros.reader[InvalidRecursive]")
+      shapeless.test.illTyped("Macros.reader[InvalidNonDoc]")
+
       val r = Macros.reader[LabelledRange]
       val doc = BSONDocument("name" -> "range1", "start" -> 2, "end" -> 5)
       val lr = LabelledRange("range1", Range(start = 2, end = 5))
@@ -433,12 +439,15 @@ class MacroSpec extends org.specs2.mutable.Specification {
     }
 
     "be generated with @Flatten annotation" in {
+      shapeless.test.illTyped("Macros.writer[InvalidRecursive]")
+      shapeless.test.illTyped("Macros.writer[InvalidNonDoc]")
+
       val w = Macros.writer[LabelledRange]
       val lr = LabelledRange("range2", Range(start = 1, end = 3))
       val doc = BSONDocument("name" -> "range2", "start" -> 1, "end" -> 3)
 
       w.write(lr) must_== doc
-    } // TODO: Test Flatten with a property Option[T : BSONDocumentWriter] ?
+    }
   }
 
   // ---

--- a/macros/src/test/scala/MacroTest.scala
+++ b/macros/src/test/scala/MacroTest.scala
@@ -6,7 +6,7 @@ import reactivemongo.bson.{
   BSONObjectID,
   Macros
 }
-import reactivemongo.bson.Macros.Annotations.{ Key, Ignore }
+import reactivemongo.bson.Macros.Annotations.{ Flatten, Key, Ignore }
 
 object MacroTest {
   type Handler[A] = BSONDocumentReader[A] with BSONDocumentWriter[A] with BSONHandler[BSONDocument, A]
@@ -173,4 +173,14 @@ object MacroTest {
   case class IgnoredAndKey(
     @Ignore a: Person,
     @Key("second") b: String)
+
+  case class Range(start: Int, end: Int)
+
+  object Range {
+    implicit val handler = Macros.handler[Range]
+  }
+
+  case class LabelledRange(
+    name: String,
+    @Flatten range: Range)
 }

--- a/macros/src/test/scala/MacroTest.scala
+++ b/macros/src/test/scala/MacroTest.scala
@@ -180,7 +180,14 @@ object MacroTest {
     implicit val handler = Macros.handler[Range]
   }
 
+  // Flatten
   case class LabelledRange(
     name: String,
     @Flatten range: Range)
+
+  case class InvalidRecursive(
+    property: String,
+    @Flatten parent: InvalidRecursive)
+
+  case class InvalidNonDoc(@Flatten name: String)
 }

--- a/project/ReactiveMongo.scala
+++ b/project/ReactiveMongo.scala
@@ -392,7 +392,9 @@ object ReactiveMongoBuild extends Build {
     file("macros"),
     settings = buildSettings ++ Findbugs.settings ++ Seq(
       libraryDependencies ++= Seq(specs,
-        "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided")
+        "org.scala-lang" % "scala-compiler" % scalaVersion.value % Provided,
+        shapelessTest % Test
+      )
     ))
     .enablePlugins(CopyPasteDetector)
     .dependsOn(bson)

--- a/project/ReactiveMongo.scala
+++ b/project/ReactiveMongo.scala
@@ -15,7 +15,7 @@ object BuildSettings {
 
   val buildSettings = Defaults.coreDefaultSettings ++ baseSettings ++ Seq(
     scalaVersion := "2.11.11",
-    crossScalaVersions := Seq("2.10.5", "2.11.11", "2.12.2"),
+    crossScalaVersions := Seq("2.10.5", "2.11.11", "2.12.3"),
     crossVersion := CrossVersion.binary,
     //parallelExecution in Test := false,
     //fork in Test := true, // Don't share executioncontext between SBT CLI/tests


### PR DESCRIPTION
```scala
case class Range(start: Int, end: Int)

case class LabelledRange(
  name: String,
  @Flatten range: Range)

// Flattened
BSONDocument("name" -> "foo", "start" -> 0, "end" -> 1)

// Rather than:
// BSONDocument("name" -> "foo", "range" -> BSONDocument(
//   "start" -> 0, "end" -> 1))
```