### PR TITLE
Do not silently restart a new tailable cursor after maxDocs is reached.

### DIFF
--- a/driver/src/main/scala/api/cursor.scala
+++ b/driver/src/main/scala/api/cursor.scala
@@ -552,9 +552,8 @@ object DefaultCursor {
               Future.failed[Option[Response]](err)
           }
         } else {
-          logger.debug("[tailResponse] Current cursor exhausted, renewing...")
-          DelayedFuture(500, connection.actorSystem).
-            flatMap { _ => makeRequest(maxDocs).map(Some(_)) }
+          logger.debug("[tailResponse] Current cursor exhausted.")
+          Future.successful(Option.empty)
         }
       }
     }

--- a/driver/src/test/scala/TailableCursorSpec.scala
+++ b/driver/src/test/scala/TailableCursorSpec.scala
@@ -43,6 +43,15 @@ trait TailableCursorSpec { specs: CursorSpec =>
           } must beEqualTo(List(0, 1, 2, 3, 4, 5)).await(1, timeout)
         }
 
+        "to fold responses and exhaust cursor" in { implicit ee: EE =>
+          implicit val reader = IdReader
+          tailable("foldrexhaust").foldResponses(List.empty[Int], 20) { (s, resp) =>
+            val bulk = Response.parse(resp).flatMap(_.asOpt[Int].toList)
+
+            Cursor.Cont(s ++ bulk)
+          } must beEqualTo(List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)).await(1, timeout)
+        }
+
         "to fold responses with async function" in { implicit ee: EE =>
           implicit val reader = IdReader
           tailable("foldr0").foldResponsesM(List.empty[Int], 6) { (s, resp) =>


### PR DESCRIPTION
Should resolve failing test of https://github.com/ReactiveMongo/ReactiveMongo-Streaming/pull/56.