### PR TITLE
Fix Cursor.collect example.

### DIFF
--- a/driver/src/main/scala/api/cursor.scala
+++ b/driver/src/main/scala/api/cursor.scala
@@ -112,7 +112,7 @@ trait Cursor[T] {
    * {{{
    * val cursor = collection.find(query, filter).cursor[BSONDocument]
    * // return the 3 first documents in a Vector[BSONDocument].
-   * val vector = cursor.collect[Vector](3, Cursor.FailOnError())
+   * val vector = cursor.collect[Vector](3, Cursor.FailOnError[Vector[BSONDocument]]())
    * }}}
    */
   def collect[M[_]](maxDocs: Int, err: ErrorHandler[M[T]])(implicit cbf: CanBuildFrom[M[_], T, M[T]], ec: ExecutionContext): Future[M[T]]


### PR DESCRIPTION
Cursor.FailOnError() will not compile, should be Cursor.FailOnError[Vector[BSONDocument]()

# Pull Request Checklist

* [✓] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [✓] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [Not needed] Have you added tests for any changed functionality? 
