### PR TITLE
fix collect maxDocs

### DIFF
--- a/driver/src/main/scala/api/cursor.scala
+++ b/driver/src/main/scala/api/cursor.scala
@@ -510,7 +510,8 @@ object DefaultCursor {
         val max = if (maxDocs < 0) Int.MaxValue else maxDocs
         val toReturn = { // normalize the number of docs to return
           if (numberToReturn > 0 && numberToReturn <= max) numberToReturn
-          else max
+          else max - (
+            response.reply.numberReturned + response.reply.startingFrom)
         }
         val op = GetMore(fullCollectionName, toReturn, response.reply.cursorID)
 

--- a/driver/src/main/scala/api/cursor.scala
+++ b/driver/src/main/scala/api/cursor.scala
@@ -511,7 +511,7 @@ object DefaultCursor {
         val toReturn = { // normalize the number of docs to return
           if (numberToReturn > 0 && numberToReturn <= max) numberToReturn
           else max - (
-            response.reply.numberReturned + response.reply.startingFrom)
+            response.reply.startingFrom + response.reply.numberReturned)
         }
         val op = GetMore(fullCollectionName, toReturn, response.reply.cursorID)
 


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [X] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [X] Have you added tests for any changed functionality?

## Purpose

Fixes reactivemongo.api.Cursor#collect method, when to collect all the documents, several requests need to be done against the DB (i.e initial query + getmore), by calculating the `ntoreturn` parameter using the previously reply `numberReturned`

## Background Context

The approach taken was to ~~revert~~update the change in this line https://github.com/ReactiveMongo/ReactiveMongo/pull/614/files#diff-500dc42c08bec244974837982a837323L602

## References

https://groups.google.com/forum/?fromgroups#!topic/reactivemongo/k7WgpPZ7opI
