### PR TITLE
Support for $replaceRoot aggregation stage

### DIFF
--- a/driver/src/main/scala/api/commands/AggregationFramework.scala
+++ b/driver/src/main/scala/api/commands/AggregationFramework.scala
@@ -413,6 +413,32 @@ trait AggregationFramework[P <: SerializationPack]
   }
 
   /**
+   * Promotes a specified document to the top level and replaces all other fields.
+   * The operation replaces all existing fields in the input document, including the _id field.
+   * https://docs.mongodb.com/manual/reference/operator/aggregation/replaceRoot
+   * @param newRoot The field name to become the new root
+   */
+  case class ReplaceRootField(newRoot: String) extends PipelineOperator {
+    import builder.{ document, elementProducer => element }
+    override val makePipe: pack.Document = document(Seq(
+      element(f"$$replaceRoot", document(Seq(
+        element("newRoot", builder.string("$" + newRoot)))))))
+  }
+
+  /**
+   * Promotes a specified document to the top level and replaces all other fields.
+   * The operation replaces all existing fields in the input document, including the _id field.
+   * https://docs.mongodb.com/manual/reference/operator/aggregation/replaceRoot
+   * @param newRoot The new root object
+   */
+  case class ReplaceRoot(newRoot: pack.Document) extends PipelineOperator {
+    import builder.{ document, elementProducer => element }
+    override val makePipe: pack.Document = document(Seq(
+      element(f"$$replaceRoot", document(Seq(
+        element("newRoot", newRoot))))))
+  }
+
+  /**
    * Outputs documents in order of nearest to farthest from a specified point.
    *
    * http://docs.mongodb.org/manual/reference/operator/aggregation/geoNear/#pipe._S_geoNear

--- a/driver/src/main/scala/core/commands/aggregation.scala
+++ b/driver/src/main/scala/core/commands/aggregation.scala
@@ -151,6 +151,26 @@ case class Ascending(field: String) extends SortOrder
 case class Descending(field: String) extends SortOrder
 
 /**
+ * Promotes a specified document to the top level and replaces all other fields.
+ * The operation replaces all existing fields in the input document, including the _id field.
+ * https://docs.mongodb.com/manual/reference/operator/aggregation/replaceRoot
+ * @param newRoot The field name to become the new root
+ */
+case class ReplaceRootField(newRoot: String) extends PipelineOperator {
+  override val makePipe = BSONDocument(f"$$replaceRoot" -> BSONDocument("newRoot" -> BSONString("$" + newRoot)))
+}
+
+/**
+ * Promotes a specified document to the top level and replaces all other fields.
+ * The operation replaces all existing fields in the input document, including the _id field.
+ * https://docs.mongodb.com/manual/reference/operator/aggregation/replaceRoot
+ * @param newRoot The new root object
+ */
+case class ReplaceRoot(newRoot: BSONDocument) extends PipelineOperator {
+  override val makePipe = BSONDocument(f"$$replaceRoot" -> BSONDocument("newRoot" -> newRoot))
+}
+
+/**
  * Represents one of the group operators for the "Group" Operation. This class is sealed
  * as these are defined in the MongoDB spec, and clients should not need to customise these.
  */

--- a/driver/src/test/scala/AggregationSpec.scala
+++ b/driver/src/test/scala/AggregationSpec.scala
@@ -1130,9 +1130,9 @@ db.accounts.aggregate([
 
           Match(document("_id" -> 1)) -> List(
             ReplaceRootField("in_stock"))
-      }.head
+      }.headOption
 
-      result must beEqualTo(document(
+      result must beSome(document(
         "oranges" -> 20,
         "apples" -> 60)).await(0, timeout)
     }
@@ -1162,9 +1162,9 @@ db.accounts.aggregate([
             ReplaceRoot(document(
               "full_name" -> document(
                 "$concat" -> array("$first_name", " ", "$last_name")))))
-      }.head
+      }.headOption
 
-      result must beEqualTo(document(
+      result must beSome(document(
         "full_name" -> "Gary Sheffield")).await(0, timeout)
     }
   }

--- a/driver/src/test/scala/AggregationSpec.scala
+++ b/driver/src/test/scala/AggregationSpec.scala
@@ -1099,6 +1099,7 @@ db.accounts.aggregate([
     }
   }
 
+  section("gt_mongo32")
   "Produce" should {
     // https://docs.mongodb.com/manual/reference/operator/aggregation/replaceRoot/#replaceroot-with-an-embedded-document
     val produce: BSONCollection = db(s"produce${System identityHashCode this}")
@@ -1168,6 +1169,7 @@ db.accounts.aggregate([
         "full_name" -> "Gary Sheffield")).await(0, timeout)
     }
   }
+  section("gt_mongo32")
 
   // ---
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #741 

## Purpose

Adds support for `$replaceRoot` aggregation stage.

## Background Context

Current version of ReactiveMongo lacks support for `$replaceRoot` out-of-box

## References

See #741 
