### PR TITLE
Improve Delete api

### DIFF
--- a/driver/src/main/scala/api/collections/DeleteOps.scala
+++ b/driver/src/main/scala/api/collections/DeleteOps.scala
@@ -55,7 +55,8 @@ trait DeleteOps[P <: SerializationPack with Singleton]
     protected def bulkRecover: Option[Exception => Future[WriteResult]]
 
     /**
-     * Performs a delete with a single selector (see [[BatchCommands.DeleteCommand.DeleteElement]]).
+     * Performs a delete with a one single selector (see [[BatchCommands.DeleteCommand.DeleteElement]]).
+     * This will delete all the documents matched by the `q` selector.
      */
     final def one[Q, U](q: Q, limit: Option[Int] = None, collation: Option[Collation] = None)(implicit ec: ExecutionContext, qw: pack.Writer[Q]): Future[WriteResult] = element[Q, U](q, limit, collation).flatMap { upd => execute(Seq(upd)) }
 
@@ -69,13 +70,13 @@ trait DeleteOps[P <: SerializationPack with Singleton]
       }
 
     /**
-     * Deletes documents, according to the [[DeleteElement]]s.
+     * Performs a bulk operation using many deletes, each can delete multiple documents.
      *
      * {{{
      * import reactivemongo.bson.BSONDocument
      * import reactivemongo.api.collections.BSONCollection
      *
-     * def deleteMany(coll: BSONCollection, docs: Iterable[BSONDocument]) = {
+     * def bulkDelete(coll: BSONCollection, docs: Iterable[BSONDocument]) = {
      *   val delete = coll.delete(ordered = true)
      *   val elements = docs.map { doc =>
      *     delete.element(

--- a/driver/src/main/scala/api/collections/DeleteOps.scala
+++ b/driver/src/main/scala/api/collections/DeleteOps.scala
@@ -55,7 +55,7 @@ trait DeleteOps[P <: SerializationPack with Singleton]
     protected def bulkRecover: Option[Exception => Future[WriteResult]]
 
     /**
-     * Performs a [[https://docs.mongodb.com/manual/reference/method/db.collection.deleteOne/ single delete]] (see [[BatchCommands.DeleteCommand.DeleteElement]]).
+     * Performs a delete with a single selector (see [[BatchCommands.DeleteCommand.DeleteElement]]).
      */
     final def one[Q, U](q: Q, limit: Option[Int] = None, collation: Option[Collation] = None)(implicit ec: ExecutionContext, qw: pack.Writer[Q]): Future[WriteResult] = element[Q, U](q, limit, collation).flatMap { upd => execute(Seq(upd)) }
 
@@ -69,7 +69,7 @@ trait DeleteOps[P <: SerializationPack with Singleton]
       }
 
     /**
-     * [[https://docs.mongodb.com/manual/reference/method/db.collection.deleteMany/ Deletes many documents]], according the ordered behaviour.
+     * Deletes documents, according to the [[DeleteElement]]s.
      *
      * {{{
      * import reactivemongo.bson.BSONDocument

--- a/driver/src/main/scala/api/collections/GenericCollection.scala
+++ b/driver/src/main/scala/api/collections/GenericCollection.scala
@@ -603,10 +603,10 @@ trait GenericCollection[P <: SerializationPack with Singleton] extends Collectio
    *
    * {{{
    * // Equivalent to:
-   * collection.delete[MyDocType](true, defaultWriteConcern).one(document)
+   * collection.delete[MyDocType](true, defaultWriteConcern).one(document, limit)
    * }}}
    */
-  @deprecated("Use [[deleteOne]] or [[deleteMany]]", "0.13.1")
+  @deprecated("Use delete().one(selector, limit)", "0.13.1")
   def remove[S](selector: S, writeConcern: WriteConcern = defaultWriteConcern, firstMatchOnly: Boolean = false)(implicit swriter: pack.Writer[S], ec: ExecutionContext): Future[WriteResult] = db.connection.metadata match {
     case Some(metadata) if (
       metadata.maxWireVersion >= MongoWireVersion.V26) => {
@@ -620,14 +620,6 @@ trait GenericCollection[P <: SerializationPack with Singleton] extends Collectio
 
     case _ =>
       Future.failed(MissingMetadata())
-  }
-
-  def deleteOne[S](selector: S, writeConcern: WriteConcern = defaultWriteConcern)(implicit swriter: pack.Writer[S], ec: ExecutionContext): Future[WriteResult] = {
-    delete(ordered = false, writeConcern).one(selector, limit = Some(1))
-  }
-
-  def deleteMany[S](selector: S, writeConcern: WriteConcern = defaultWriteConcern)(implicit swriter: pack.Writer[S], ec: ExecutionContext): Future[WriteResult] = {
-    delete(ordered = false, writeConcern).one(selector, limit = None)
   }
 
   private def writeDoc[T](

--- a/driver/src/main/scala/api/collections/GenericCollection.scala
+++ b/driver/src/main/scala/api/collections/GenericCollection.scala
@@ -606,7 +606,7 @@ trait GenericCollection[P <: SerializationPack with Singleton] extends Collectio
    * collection.delete[MyDocType](true, defaultWriteConcern).one(document)
    * }}}
    */
-  @deprecated("Use [[delete]]", "0.13.1")
+  @deprecated("Use [[deleteOne]] or [[deleteMany]]", "0.13.1")
   def remove[S](selector: S, writeConcern: WriteConcern = defaultWriteConcern, firstMatchOnly: Boolean = false)(implicit swriter: pack.Writer[S], ec: ExecutionContext): Future[WriteResult] = db.connection.metadata match {
     case Some(metadata) if (
       metadata.maxWireVersion >= MongoWireVersion.V26) => {
@@ -620,6 +620,14 @@ trait GenericCollection[P <: SerializationPack with Singleton] extends Collectio
 
     case _ =>
       Future.failed(MissingMetadata())
+  }
+
+  def deleteOne[S](selector: S, writeConcern: WriteConcern = defaultWriteConcern)(implicit swriter: pack.Writer[S], ec: ExecutionContext): Future[WriteResult] = {
+    delete(ordered = false, writeConcern).one(selector, limit = Some(1))
+  }
+
+  def deleteMany[S](selector: S, writeConcern: WriteConcern = defaultWriteConcern)(implicit swriter: pack.Writer[S], ec: ExecutionContext): Future[WriteResult] = {
+    delete(ordered = false, writeConcern).one(selector, limit = None)
   }
 
   private def writeDoc[T](

--- a/driver/src/main/scala/api/collections/GenericCollection.scala
+++ b/driver/src/main/scala/api/collections/GenericCollection.scala
@@ -637,7 +637,7 @@ trait GenericCollection[P <: SerializationPack with Singleton] extends Collectio
    * @param writeConcern $writeConcernParam
    *
    */
-  def delete[S](ordered: Boolean, writeConcern: WriteConcern): DeleteBuilder =
+  def delete[S](ordered: Boolean = true, writeConcern: WriteConcern = defaultWriteConcern): DeleteBuilder =
     prepareDelete(ordered, writeConcern)
 
   /**

--- a/driver/src/main/scala/api/gridfs.scala
+++ b/driver/src/main/scala/api/gridfs.scala
@@ -462,9 +462,9 @@ class GridFS[P <: SerializationPack with Singleton](db: DB with DBMetaCommands, 
    * @param id the file id to remove from this store
    */
   def remove[Id <: pack.Value](id: Id)(implicit ctx: ExecutionContext, idProducer: IdProducer[Id]): Future[WriteResult] =
-    asBSON(chunks.name).deleteMany(BSONDocument(idProducer("files_id" -> id))).
+    asBSON(chunks.name).delete().one(BSONDocument(idProducer("files_id" -> id)), limit = None).
       flatMap { _ =>
-        asBSON(files.name).deleteMany(BSONDocument(idProducer("_id" -> id)))
+        asBSON(files.name).delete().one(BSONDocument(idProducer("_id" -> id)), limit = None)
       }
 
   /**

--- a/driver/src/main/scala/api/gridfs.scala
+++ b/driver/src/main/scala/api/gridfs.scala
@@ -462,9 +462,9 @@ class GridFS[P <: SerializationPack with Singleton](db: DB with DBMetaCommands, 
    * @param id the file id to remove from this store
    */
   def remove[Id <: pack.Value](id: Id)(implicit ctx: ExecutionContext, idProducer: IdProducer[Id]): Future[WriteResult] =
-    asBSON(chunks.name).remove(BSONDocument(idProducer("files_id" -> id))).
+    asBSON(chunks.name).deleteMany(BSONDocument(idProducer("files_id" -> id))).
       flatMap { _ =>
-        asBSON(files.name).remove(BSONDocument(idProducer("_id" -> id)))
+        asBSON(files.name).deleteMany(BSONDocument(idProducer("_id" -> id)))
       }
 
   /**

--- a/driver/src/main/scala/api/gridfs.scala
+++ b/driver/src/main/scala/api/gridfs.scala
@@ -462,9 +462,9 @@ class GridFS[P <: SerializationPack with Singleton](db: DB with DBMetaCommands, 
    * @param id the file id to remove from this store
    */
   def remove[Id <: pack.Value](id: Id)(implicit ctx: ExecutionContext, idProducer: IdProducer[Id]): Future[WriteResult] =
-    asBSON(chunks.name).delete().one(BSONDocument(idProducer("files_id" -> id)), limit = None).
+    asBSON(chunks.name).delete().one(BSONDocument(idProducer("files_id" -> id))).
       flatMap { _ =>
-        asBSON(files.name).delete().one(BSONDocument(idProducer("_id" -> id)), limit = None)
+        asBSON(files.name).delete().one(BSONDocument(idProducer("_id" -> id)))
       }
 
   /**

--- a/driver/src/test/scala/CollectionSpec.scala
+++ b/driver/src/test/scala/CollectionSpec.scala
@@ -235,7 +235,7 @@ class CollectionSpec(implicit protected val ee: ExecutionEnv)
         "name" -> BSONJavaScript("db.getName()"))).flatMap { _ =>
         find.map(_.flatMap(_.getAs[BSONJavaScript]("name")).map(_.value))
       } aka "inserted" must beSome("db.getName()").await(1, timeout) and {
-        collection.remove(selector).map(_.n) must beTypedEqualTo(1).
+        collection.deleteMany(selector).map(_.n) must beTypedEqualTo(1).
           await(1, timeout)
       } and {
         find must beNone.await(1, timeout)

--- a/driver/src/test/scala/CollectionSpec.scala
+++ b/driver/src/test/scala/CollectionSpec.scala
@@ -235,7 +235,7 @@ class CollectionSpec(implicit protected val ee: ExecutionEnv)
         "name" -> BSONJavaScript("db.getName()"))).flatMap { _ =>
         find.map(_.flatMap(_.getAs[BSONJavaScript]("name")).map(_.value))
       } aka "inserted" must beSome("db.getName()").await(1, timeout) and {
-        collection.delete().one(selector, limit = None).map(_.n) must beTypedEqualTo(1).
+        collection.delete().one(selector).map(_.n) must beTypedEqualTo(1).
           await(1, timeout)
       } and {
         find must beNone.await(1, timeout)

--- a/driver/src/test/scala/CollectionSpec.scala
+++ b/driver/src/test/scala/CollectionSpec.scala
@@ -235,7 +235,7 @@ class CollectionSpec(implicit protected val ee: ExecutionEnv)
         "name" -> BSONJavaScript("db.getName()"))).flatMap { _ =>
         find.map(_.flatMap(_.getAs[BSONJavaScript]("name")).map(_.value))
       } aka "inserted" must beSome("db.getName()").await(1, timeout) and {
-        collection.deleteMany(selector).map(_.n) must beTypedEqualTo(1).
+        collection.delete().one(selector, limit = None).map(_.n) must beTypedEqualTo(1).
           await(1, timeout)
       } and {
         find must beNone.await(1, timeout)


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [X] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [X] Have you added tests for any changed functionality? Yes by changing existing `remove` tests

## Purpose

Adds default parameters to `GenericCollection#delete` and introduces `GenericCollection#deleteOne` and `GenericCollection#deleteMany`. I also changed the tests to not use deprecated methods

## Background Context

I tried to replicate the default parameters for `GenericCollection#delete` as described in https://docs.mongodb.com/manual/reference/command/delete/
I introduced `GenericCollection#deleteOne` and `GenericCollection#deleteMany` as described in https://docs.mongodb.com/manual/reference/method/db.collection.deleteOne/ and https://docs.mongodb.com/manual/reference/method/db.collection.deleteMany/ as syntax sugar over the collection API

## References

https://groups.google.com/forum/#!topic/reactivemongo/9Sjq-qQg61Y
