### PR TITLE
remove jdk7 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,6 @@ matrix:
     jdk: openjdk8
     scala: 2.12.6
   - os: linux
-    jdk: oraclejdk7
-    scala: 2.11.12
-    env: CI_CATEGORY=INTEGRATION_TESTS AKKA_VERSION=2.3.13 ITERATEES_VERSION=2.3.8 MONGO_PROFILE=default MONGO_VER=2_6
-  - os: linux
     jdk: openjdk8
     scala: 2.12.6
     env: CI_CATEGORY=INTEGRATION_TESTS AKKA_VERSION=2.5.13 ITERATEES_VERSION=2.6.1 MONGO_PROFILE=default MONGO_VER=3


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [x] Have you added tests for any changed functionality?

## Fixes



## Purpose

remove jdk7 build

## Background Context

sbt 1.x does not support jdk7. Also travis-ci no longer support oraclejdk7. see oraclejdk7 build logs

https://travis-ci.org/ReactiveMongo/ReactiveMongo/jobs/399507438#L416

```
$ jdk_switcher use oraclejdk7
Switching to Oracle JDK7 (java-7-oracle), JAVA_HOME will be set to /usr/lib/jvm/java-7-oracle
update-java-alternatives: directory does not exist: /usr/lib/jvm/java-7-oracle
```

https://travis-ci.org/ReactiveMongo/ReactiveMongo/jobs/399507438#L497

```
$ java -Xmx32m -version
java version "1.8.0_151"
Java(TM) SE Runtime Environment (build 1.8.0_151-b12)
Java HotSpot(TM) 64-Bit Server VM (build 25.151-b12, mixed mode)
```


## References

https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879