### PR TITLE
Correcting Log4J direct usage in compile scope.

### DIFF
--- a/driver/src/main/scala/utils.scala
+++ b/driver/src/main/scala/utils.scala
@@ -46,7 +46,7 @@ object `package` {
 
 @deprecated(
   message = "Use [[reactivemongo.util.LazyLogger]]", since = "0.12.0")
-case class LazyLogger(logger: org.apache.logging.log4j.Logger) {
+case class LazyLogger(logger: org.slf4j.Logger) {
   def trace(s: => String): Unit = { if (logger.isTraceEnabled) logger.trace(s) }
   def trace(s: => String, e: => Throwable): Unit = { if (logger.isTraceEnabled) logger.trace(s, e) }
   def debug(s: => String): Unit = { if (logger.isDebugEnabled) logger.debug(s) }
@@ -63,7 +63,7 @@ case class LazyLogger(logger: org.apache.logging.log4j.Logger) {
   message = "Use [[reactivemongo.util.LazyLogger]]", since = "0.12.0")
 object LazyLogger {
   def apply(logger: String): LazyLogger =
-    LazyLogger(org.apache.logging.log4j.LogManager.getLogger(logger))
+    LazyLogger(org.slf4j.LoggerFactory.getLogger(logger))
 }
 
 @deprecated(

--- a/project/ReactiveMongo.scala
+++ b/project/ReactiveMongo.scala
@@ -130,20 +130,19 @@ object Dependencies {
     "org.specs2" %% "specs2-core" % specsVer.value % Test
   }
 
-  val slf4jVer = "1.7.12"
+  val slf4jVer = "1.7.21"
   val log4jVer = "2.5"
 
   val slf4j = "org.slf4j" % "slf4j-api" % slf4jVer
-  val slf4jSimple = "org.slf4j" % "slf4j-simple" % slf4jVer
 
   val logApi = Seq(
-    slf4j % "provided",
-    "org.apache.logging.log4j" % "log4j-api" % log4jVer // deprecated
-  ) ++ Seq("log4j-core", "log4j-slf4j-impl").map(
-    "org.apache.logging.log4j" % _ % log4jVer % Test)
+    slf4j,
+    "org.apache.logging.log4j" % "log4j-api" % log4jVer % Test,
+    "org.apache.logging.log4j" % "log4j-core" % log4jVer % Test,
+    "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4jVer % Test
+  )
 
   val shapelessTest = "com.chuusai" %% "shapeless" % "2.3.3"
-
   val commonsCodec = "commons-codec" % "commons-codec" % "1.11"
 }
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes direct usage of Log4J in the compile scope of the project. It's not a good pattern to enforce a specific logging implementation onto consumers of ReactiveMongo, and no implementation details should rely on a specific implementation of the SLF4J facade.

## Purpose

Removes directly dependency on Log4J inside the compile scope, and moves it to test scope only instead. `LazyLogging` correctly delegates to the logging facade now.

## Background Context

Lots of users, ourselves included, use ReactiveMongo widely throughout projects. For various, perhaps legacy concerns, we cannot pick Log4J2 and instead rely on Logback. ReactiveMongo should not be, as a library, the piece of software forcing us down one path or the other, as this causes ReactiveMongo specific logging to completely breakdown and go missing in our projects.