### PR TITLE
ambiguous implicits with new find api (0.16).

### DIFF
--- a/driver/src/test/scala/CollectionSpec.scala
+++ b/driver/src/test/scala/CollectionSpec.scala
@@ -44,7 +44,7 @@ class CollectionSpec(implicit protected val ee: ExecutionEnv)
             } must beTypedEqualTo(true -> 1).await(1, timeout)
           }
         } and {
-          slowColl.find(BSONDocument.empty).cursor[BSONDocument]().
+          slowColl.find(BSONDocument.empty, projection = None).cursor[BSONDocument]().
             collect[List](-1, Cursor.FailOnError[List[BSONDocument]]()).
             map(_.size) must beTypedEqualTo(2).await(1, slowTimeout)
         }


### PR DESCRIPTION
This fails at compile with
```
[error] /home/giraudeau/external-scm/ReactiveMongo/driver/src/test/scala/CollectionSpec.scala:47:24: ambiguous implicit values:
[error]  both object BSONDocumentIdentity in trait DefaultBSONHandlers of type reactivemongo.bson.package.BSONDocumentIdentity.type
[error]  and value writer of type CollectionSpec.this.PersonWriter.type
[error]  match expected type CollectionSpec.this.slowColl.pack.Writer[J]
[error]           slowColl.find(BSONDocument.empty, projection = None).cursor[BSONDocument]().
[error]                        ^
```