### PR TITLE
fix scala 2.10 compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,14 @@ matrix:
     jdk: oraclejdk9
     scala: 2.12.6
   - os: linux
+    env: CI_CATEGORY=UNIT_TESTS
+    jdk: oraclejdk9
+    scala: 2.11.12
+  - os: linux
+    env: CI_CATEGORY=UNIT_TESTS
+    jdk: oraclejdk9
+    scala: 2.10.7
+  - os: linux
     jdk: openjdk8
     scala: 2.11.12
     env: CI_CATEGORY=INTEGRATION_TESTS AKKA_VERSION=2.3.13 ITERATEES_VERSION=2.3.8 MONGO_PROFILE=default MONGO_VER=2_6 PUBLISHABLE=yes

--- a/driver/src/main/scala/api/commands/GroupAggregation.scala
+++ b/driver/src/main/scala/api/commands/GroupAggregation.scala
@@ -5,7 +5,7 @@ import reactivemongo.api.SerializationPack
 private[commands] trait GroupAggregation[P <: SerializationPack] {
   aggregation: AggregationFramework[P] =>
 
-  @inline private def document(name: String, arg: pack.Value): pack.Document =
+  @inline private def $document(name: String, arg: pack.Value): pack.Document =
     builder.document(Seq(builder.elementProducer(name, arg)))
 
   /**
@@ -28,88 +28,88 @@ private[commands] trait GroupAggregation[P <: SerializationPack] {
      */
     def apply(name: String, arg: pack.Value): GroupFunction =
       new GroupFunction {
-        val makeFunction = document(name, arg)
+        val makeFunction = $document(name, arg)
       }
   }
 
   // ---
 
   case class SumField(field: String) extends GroupFunction {
-    val makeFunction = document(f"$$sum", builder.string("$" + field))
+    val makeFunction = $document(f"$$sum", builder.string("$" + field))
   }
 
   /**
    * @param sumExpr the `\$sum` expression
    */
   case class Sum(sumExpr: pack.Value) extends GroupFunction {
-    val makeFunction: pack.Document = document(f"$$sum", sumExpr)
+    val makeFunction: pack.Document = $document(f"$$sum", sumExpr)
   }
 
   /** Sum operation of the form `\$sum: 1` */
   case object SumAll extends GroupFunction {
-    val makeFunction = document(f"$$sum", builder.int(1))
+    val makeFunction = $document(f"$$sum", builder.int(1))
   }
 
   @deprecated("Use [[SumAll]]", "0.12.0")
   case class SumValue(value: Int) extends GroupFunction {
-    val makeFunction = document(f"$$sum", builder.int(value))
+    val makeFunction = $document(f"$$sum", builder.int(value))
   }
 
   case class AvgField(field: String) extends GroupFunction {
-    val makeFunction = document(f"$$avg", builder.string("$" + field))
+    val makeFunction = $document(f"$$avg", builder.string("$" + field))
   }
 
   case class Avg(avgExpr: pack.Value) extends GroupFunction {
-    val makeFunction = document(f"$$avg", avgExpr)
+    val makeFunction = $document(f"$$avg", avgExpr)
   }
 
   case class FirstField(field: String) extends GroupFunction {
-    val makeFunction = document(f"$$first", builder.string("$" + field))
+    val makeFunction = $document(f"$$first", builder.string("$" + field))
   }
 
   case class First(firstExpr: pack.Value) extends GroupFunction {
-    val makeFunction = document(f"$$first", firstExpr)
+    val makeFunction = $document(f"$$first", firstExpr)
   }
 
   case class LastField(field: String) extends GroupFunction {
-    val makeFunction = document(f"$$last", builder.string("$" + field))
+    val makeFunction = $document(f"$$last", builder.string("$" + field))
   }
 
   case class Last(lastExpr: pack.Value) extends GroupFunction {
-    val makeFunction = document(f"$$last", lastExpr)
+    val makeFunction = $document(f"$$last", lastExpr)
   }
 
   case class MaxField(field: String) extends GroupFunction {
-    val makeFunction = document(f"$$max", builder.string("$" + field))
+    val makeFunction = $document(f"$$max", builder.string("$" + field))
   }
 
   /**
    * @param maxExpr the `\$max` expression
    */
   case class Max(maxExpr: pack.Value) extends GroupFunction {
-    val makeFunction = document(f"$$max", maxExpr)
+    val makeFunction = $document(f"$$max", maxExpr)
   }
 
   case class MinField(field: String) extends GroupFunction {
-    val makeFunction = document(f"$$min", builder.string("$" + field))
+    val makeFunction = $document(f"$$min", builder.string("$" + field))
   }
 
   /**
    * @param minExpr the `\$min` expression
    */
   case class Min(minExpr: pack.Value) extends GroupFunction {
-    val makeFunction = document(f"$$min", minExpr)
+    val makeFunction = $document(f"$$min", minExpr)
   }
 
   case class PushField(field: String) extends GroupFunction {
-    val makeFunction = document(f"$$push", builder.string("$" + field))
+    val makeFunction = $document(f"$$push", builder.string("$" + field))
   }
 
   /**
    * @param pushExpr the `\$push` expression
    */
   case class Push(pushExpr: pack.Value) extends GroupFunction {
-    val makeFunction = document(f"$$push", pushExpr)
+    val makeFunction = $document(f"$$push", pushExpr)
   }
 
   /**
@@ -119,37 +119,37 @@ private[commands] trait GroupAggregation[P <: SerializationPack] {
    * @see https://docs.mongodb.com/manual/reference/operator/aggregation/addFields/
    */
   case class AddFields(specifications: pack.Document) extends PipelineOperator {
-    val makePipe = document(f"$$addFields", specifications)
+    val makePipe = $document(f"$$addFields", specifications)
   }
 
   case class AddFieldToSet(field: String) extends GroupFunction {
-    val makeFunction = document(f"$$addToSet", builder.string("$" + field))
+    val makeFunction = $document(f"$$addToSet", builder.string("$" + field))
   }
 
   /**
    * @param addToSetExpr the `\$addToSet` expression
    */
   case class AddToSet(addToSetExpr: pack.Value) extends GroupFunction {
-    val makeFunction = document(f"$$addToSet", addToSetExpr)
+    val makeFunction = $document(f"$$addToSet", addToSetExpr)
   }
 
   /** The [[https://docs.mongodb.com/manual/reference/operator/aggregation/stdDevPop/ \$stdDevPop]] group accumulator (since MongoDB 3.2) */
   case class StdDevPop(expression: pack.Value) extends GroupFunction {
-    val makeFunction = document(f"$$stdDevPop", expression)
+    val makeFunction = $document(f"$$stdDevPop", expression)
   }
 
   /** The [[https://docs.mongodb.com/manual/reference/operator/aggregation/stdDevPop/ \$stdDevPop]] for a single field (since MongoDB 3.2) */
   case class StdDevPopField(field: String) extends GroupFunction {
-    val makeFunction = document(f"$$stdDevPop", builder.string("$" + field))
+    val makeFunction = $document(f"$$stdDevPop", builder.string("$" + field))
   }
 
   /** The [[https://docs.mongodb.com/manual/reference/operator/aggregation/stdDevSamp/ \$stdDevSamp]] group accumulator (since MongoDB 3.2) */
   case class StdDevSamp(expression: pack.Value) extends GroupFunction {
-    val makeFunction = document(f"$$stdDevSamp", expression)
+    val makeFunction = $document(f"$$stdDevSamp", expression)
   }
 
   /** The [[https://docs.mongodb.com/manual/reference/operator/aggregation/stdDevSamp/ \$stdDevSamp]] for a single field (since MongoDB 3.2) */
   case class StdDevSampField(field: String) extends GroupFunction {
-    val makeFunction = document(f"$$stdDevSamp", builder.string("$" + field))
+    val makeFunction = $document(f"$$stdDevSamp", builder.string("$" + field))
   }
 }


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [X] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [X] Have you added tests for any changed functionality?

## Fixes

Although scala 2.10 is still a supported target, Travis was not configured to compile with scala 2.10. This PR fixes that and also an compilation issue in tests...

## Purpose

Adds scala 2.10 compilation to travis.yml

