### PR TITLE
Reconnect after a configurable delay

### DIFF
--- a/driver/src/main/scala/api/MongoConnection.scala
+++ b/driver/src/main/scala/api/MongoConnection.scala
@@ -633,6 +633,9 @@ object MongoConnection {
           case ("rm.nbChannelsPerNode", v) => unsupported -> result.
             copy(nbChannelsPerNode = v.toInt)
 
+          case ("rm.reconnectDelayMS", v) => unsupported -> result.
+            copy(reconnectDelayMS = v.toInt)
+
           case ("writeConcern", "unacknowledged") => unsupported -> result.
             copy(writeConcern = WC.Unacknowledged)
 

--- a/driver/src/main/scala/api/MongoConnectionOptions.scala
+++ b/driver/src/main/scala/api/MongoConnectionOptions.scala
@@ -48,6 +48,7 @@ case class MongoConnectionOptions(
   tcpNoDelay: Boolean = false,
   keepAlive: Boolean = false,
   nbChannelsPerNode: Int = 10,
+  reconnectDelayMS: Int = 1000,
 
   // read and write preferences
   writeConcern: WC = WC.Default,
@@ -125,6 +126,7 @@ object MongoConnectionOptions {
       "maxIdleTimeMS" -> ms(options.maxIdleTimeMS), // TODO: Review
       "tcpNoDelay" -> options.tcpNoDelay.toString,
       "keepAlive" -> options.keepAlive.toString,
+      "reconnectDelayMS" -> options.reconnectDelayMS.toString,
       "sslEnabled" -> options.sslEnabled.toString,
       "sslAllowsInvalidCert" -> options.sslAllowsInvalidCert.toString,
       "writeConcern" -> options.writeConcern.toString,

--- a/driver/src/main/scala/core/nodeset/ChannelFactory.scala
+++ b/driver/src/main/scala/core/nodeset/ChannelFactory.scala
@@ -1,5 +1,6 @@
 package reactivemongo.core.nodeset // TODO: Move to `netty` package
 
+import java.util.concurrent.TimeUnit
 import java.lang.{ Boolean => JBool }
 
 import scala.concurrent.Promise
@@ -71,7 +72,12 @@ private[reactivemongo] final class ChannelFactory(
               s"Connection to ${host}:${port} refused for channel #${chanId}",
               op.cause)
 
-            receiver ! ChannelDisconnected(chanId)
+            op.channel().eventLoop().schedule(new Runnable {
+              def run(): Unit = {
+                receiver ! ChannelDisconnected(chanId)
+              }
+            }, options.reconnectDelayMS, TimeUnit.MILLISECONDS)
+
           }
         }
       })

--- a/driver/src/test/scala/DatabaseSpec.scala
+++ b/driver/src/test/scala/DatabaseSpec.scala
@@ -43,7 +43,7 @@ class DatabaseSpec(implicit ee: ExecutionEnv)
           await(0, estmout * 2) and {
             val duration = System.currentTimeMillis() - before
 
-            duration must be_<(estmout.toMillis + 1000 /* ms */ )
+            duration must be_<(estmout.toMillis + 2000 /* ms */ )
           }
       } tag "unit"
     }


### PR DESCRIPTION
# Pull Request Checklist

* [ x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [ x] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [ x] Have you added tests for any changed functionality?

## Fixes

This fixes performance problems when one of the nodes in the replica set is down and RM tries to reconnect.

## Purpose

This PR introduces a non-blocking, configurable delay for reconnecting when a node is down.

## Background Context

The current version of RM since 0.15.1+ has a performance problem with reconnecting. It tries to reconnect as soon as connection fails. Then reconnect fails again and it goes in a loop as long as a node is down. Reconnecting attempts can happen 1000s times per second impacting the performance of the entire app and maxing out cpu. This is regardless of logging level that is set. A better approach in my opinion is to retry after some delay. I have arbitrarily chosen 1000 ms but I'm not married to this number and the PR lets users choose incl 0ms if they want current behaviour.

This problem seems to be system specific. I was able to reproduce on several linux boxes but problem doesn't happen on Macs, at least on Macs I tested. I don't know what causes the problem or difference between systems but after the fix everything continues to work fine on Macs and also works on linux.

ReactiveMongo generally doesn't do anything platform specific but it uses Netty which has a history of problems with specific linux kernel versions, e.g. https://github.com/netty/netty/issues/2616.

## References

Are there any relevant issues / PRs / mailing lists discussions?
https://groups.google.com/forum/#!topic/reactivemongo/UK26oAL4eIo