### PR TITLE
Adjust seedList test case to take options into account

### DIFF
--- a/driver/src/test/scala/MongoURISpec.scala
+++ b/driver/src/test/scala/MongoURISpec.scala
@@ -467,7 +467,7 @@ class MongoURISpec(implicit ee: ExecutionEnv)
             Name.fromConstantString("mongo1.domain.tld.")))),
         txts = txtResolver({ name =>
           if (name == "service.domain.tld") {
-            ListSet("authenticationMechanism=scram-sha1", "foo=lorem")
+            ListSet("authenticationMechanism=scram-sha1", "authenticationDatabase=admin&ignore=this")
           } else {
             throw new IllegalArgumentException(s"Unexpected: $name")
           }
@@ -476,13 +476,13 @@ class MongoURISpec(implicit ee: ExecutionEnv)
             hosts = List("mongo1.domain.tld" -> 27017),
             db = Some("somedb"),
             authenticate = Some(
-              Authenticate("somedb", "user123", Some("passwd123"))),
+              Authenticate("admin", "user123", Some("passwd123"))),
             options = MongoConnectionOptions(
               sslEnabled = false, // overriden from URI
               authenticationMechanism = ScramSha1Authentication,
               credentials = Map("somedb" -> Credential(
                 "user123", Some("passwd123")))),
-            ignoredOptions = List("foo")))
+            ignoredOptions = List("foo", "ignore")))
 
     }
   }


### PR DESCRIPTION
Currently, the options given from the TXT DNS records are simply
ignored since the `parseOptions` method actually expects `uriAndOptions`
as an argument.

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [ ] Have you added tests for any changed functionality?

## Purpose

Provides a failing test case for an issue.
