### PR TITLE
Fix `IllegalReferenceCountException` in `ResponseDecoder`

### DIFF
--- a/driver/src/main/scala/core/protocol/protocol.scala
+++ b/driver/src/main/scala/core/protocol/protocol.scala
@@ -283,7 +283,6 @@ private[reactivemongo] class ResponseDecoder
       val docs = Unpooled.buffer(frame.readableBytes)
 
       docs.writeBytes(frame)
-      frame.release()
 
       ResponseDecoder.first(docs) match {
         case Failure(cause) => {
@@ -339,7 +338,6 @@ private[reactivemongo] class ResponseDecoder
       val docs = Unpooled.buffer(frame.readableBytes)
 
       docs.writeBytes(frame)
-      frame.release()
 
       Response(header, reply, docs, info)
     } else {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [x] Have you added tests for any changed functionality?

## Purpose

This fixes `io.netty.util.IllegalReferenceCountException`s to be thrown constantly in the `ResponseDecoder`. I noticed these exceptions when debugging [another problem](https://stackoverflow.com/questions/54706942/mongoerror-no-primary-node-is-available-decoderexception) we're seeing regarding "No primary node available" errors.

## Background Context

```
reactivemongo.io.netty.handler.codec.DecoderException: reactivemongo.io.netty.util.IllegalReferenceCountException: refCnt: 0, decrement: 1
 	at reactivemongo.io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:98)
 	at reactivemongo.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
 	at reactivemongo.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
 	at reactivemongo.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
 	at reactivemongo.io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:323)
 	at reactivemongo.io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:297)
 	at reactivemongo.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
 	at reactivemongo.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
 	at reactivemongo.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
 	at reactivemongo.io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1432)
 Caused by: reactivemongo.io.netty.util.IllegalReferenceCountException: refCnt: 0, decrement: 1
 	at reactivemongo.io.netty.buffer.AbstractReferenceCountedByteBuf.release0(AbstractReferenceCountedByteBuf.java:124)
 	at reactivemongo.io.netty.buffer.AbstractReferenceCountedByteBuf.release(AbstractReferenceCountedByteBuf.java:107)
 	at reactivemongo.io.netty.util.ReferenceCountUtil.release(ReferenceCountUtil.java:88)
 	at reactivemongo.io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:90)
 	at reactivemongo.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
 	at reactivemongo.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
 	at reactivemongo.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
 	at reactivemongo.io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:323)
 	at reactivemongo.io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:297)
 	at reactivemongo.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
```
since the decoder will [release the ByteBuf itself](https://netty.io/4.1/api/io/netty/handler/codec/MessageToMessageDecoder.html)

> Be aware that you need to call ReferenceCounted.retain() on messages that are
> just passed through if they are of type ReferenceCounted. This is needed as
> the MessageToMessageDecoder will call ReferenceCounted.release() on decoded
>  messages.

I do not know (yet) whether this fixes my initial problem, but keeping it running under `-Dio.netty.leakDetectionLevel=paranoid` neither showed any leaks nor any `IllegalReferenceCountException` anymore.