### PR TITLE
Accept null as none

### DIFF
--- a/bson/src/main/scala/exceptions.scala
+++ b/bson/src/main/scala/exceptions.scala
@@ -21,10 +21,6 @@ case class DocumentKeyNotFound(name: String) extends Exception {
   override def getMessage = s"The key '$name' could not be found in this document or array"
 }
 
-case class DocumentKeyIsNull(name: String) extends Exception {
-  override def getMessage = s"The key '$name' is null"
-}
-
 case class TypeDoesNotMatch(message: String)
   extends Exception with NoStackTrace {
   override val getMessage = message

--- a/bson/src/main/scala/exceptions.scala
+++ b/bson/src/main/scala/exceptions.scala
@@ -21,6 +21,10 @@ case class DocumentKeyNotFound(name: String) extends Exception {
   override def getMessage = s"The key '$name' could not be found in this document or array"
 }
 
+case class DocumentKeyIsNull(name: String) extends Exception {
+  override def getMessage = s"The key '$name' is null"
+}
+
 case class TypeDoesNotMatch(message: String)
   extends Exception with NoStackTrace {
   override val getMessage = message

--- a/bson/src/main/scala/types.scala
+++ b/bson/src/main/scala/types.scala
@@ -996,9 +996,11 @@ case class BSONDocument(stream: Stream[Try[BSONElement]])
    */
   def getAsTry[T](key: String)(implicit reader: BSONReader[_ <: BSONValue, T]): Try[T] = {
     val tt = getTry(key)
-    tt.flatMap { element: BSONValue =>
-      Try(reader.asInstanceOf[BSONReader[BSONValue, T]].read(element))
-        .recoverWith { case _ if element == BSONNull => Failure(DocumentKeyNotFound(key)) }
+    tt.flatMap {
+      case BSONNull =>
+        Failure(DocumentKeyNotFound(key))
+      case element =>
+        Try(reader.asInstanceOf[BSONReader[BSONValue, T]].read(element))
     }
   }
 

--- a/bson/src/main/scala/types.scala
+++ b/bson/src/main/scala/types.scala
@@ -17,7 +17,7 @@ package reactivemongo.bson
 
 import java.math.{ BigDecimal => JBigDec }
 
-import exceptions.{ DocumentKeyNotFound, DocumentKeyIsNull }
+import exceptions.DocumentKeyNotFound
 import scala.util.{ Failure, Success, Try }
 import buffer._
 import utils.Converters
@@ -998,7 +998,7 @@ case class BSONDocument(stream: Stream[Try[BSONElement]])
     val tt = getTry(key)
     tt.flatMap { element: BSONValue =>
       Try(reader.asInstanceOf[BSONReader[BSONValue, T]].read(element))
-        .recoverWith { case _ if element == BSONNull => Failure(DocumentKeyIsNull(key)) }
+        .recoverWith { case _ if element == BSONNull => Failure(DocumentKeyNotFound(key)) }
     }
   }
 
@@ -1009,9 +1009,9 @@ case class BSONDocument(stream: Stream[Try[BSONElement]])
    * If the value could not be deserialized or converted, returns a `Failure`.
    */
   def getAsUnflattenedTry[T](key: String)(implicit reader: BSONReader[_ <: BSONValue, T]): Try[Option[T]] = getAsTry(key)(reader) match {
-    case Failure(_: DocumentKeyNotFound) | Failure(_: DocumentKeyIsNull) => Success(None)
-    case Failure(e) => Failure(e)
-    case Success(e) => Success(Some(e))
+    case Failure(_: DocumentKeyNotFound) => Success(None)
+    case Failure(e)                      => Failure(e)
+    case Success(e)                      => Success(Some(e))
   }
 
   /** Creates a new [[BSONDocument]] containing all the elements of this one and the elements of the given document. */

--- a/macros/src/test/scala/MacroSpec.scala
+++ b/macros/src/test/scala/MacroSpec.scala
@@ -8,6 +8,7 @@ import reactivemongo.bson.{
   BSONDouble,
   BSONHandler,
   BSONInteger,
+  BSONNull,
   BSONReader,
   BSONString,
   BSONWriter,
@@ -52,6 +53,13 @@ class MacroSpec extends org.specs2.mutable.Specification {
         BSONDocument(
           "name" -> "invalidValueType",
           "value" -> 4)) must throwA[Exception]("BSONInteger")
+    }
+
+    "support null for optional value" in {
+      Macros.reader[Optional].read(
+        BSONDocument(
+          "name" -> "name",
+          "value" -> BSONNull)).value must be(None)
     }
 
     "support seq" in {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes Option parsing when the key is null.

## Purpose

This PR allows to be more lenient when parsing a null which we expect to be an option. `null` is now accepted as `None` value.

## Background Context

in `0.16.0`, any error encountered while parsing an option resulted in a None. This was fixed to fail when the key actually contains something which does not match the expected type. 

However, having a null also fails now, which is probably not what we expect. 

## References

 - Original topic on the mailing list : https://groups.google.com/forum/?nomobile=true#!topic/reactivemongo/o7coQZEniqw
 - PR which solved the "every error interpreted as None" behaviour : #781 
