### PR TITLE
Use `System.nanoTime()` instead of `System.currentTimeMillis()`

### DIFF
--- a/driver/src/main/scala/core/actors/MongoDBSystem.scala
+++ b/driver/src/main/scala/core/actors/MongoDBSystem.scala
@@ -37,7 +37,7 @@ import reactivemongo.io.netty.channel.group.{
   DefaultChannelGroup
 }
 
-import reactivemongo.util.LazyLogger
+import reactivemongo.util.{ LazyLogger, timestamp }
 import reactivemongo.core.errors.GenericDriverException
 import reactivemongo.core.protocol.{
   GetMore,
@@ -157,7 +157,7 @@ trait MongoDBSystem extends Actor {
   // <-- monitor
 
   @inline private def updateHistory(event: String) =
-    syncHistory.offer(System.currentTimeMillis() -> event)
+    syncHistory.offer(timestamp() -> event)
 
   private[reactivemongo] def internalState() = new InternalState(
     history.toArray(Array.fill[(Long, String)](historyMax)(null)).
@@ -948,7 +948,7 @@ trait MongoDBSystem extends Actor {
                 // No longer waiting response for isMaster,
                 // reset the pending state, and update the ping time
                 val pingTime =
-                  System.currentTimeMillis() - node.pingInfo.lastIsMasterTime
+                  timestamp() - node.pingInfo.lastIsMasterTime
 
                 node.pingInfo.copy(
                   ping = pingTime,
@@ -1363,7 +1363,7 @@ trait MongoDBSystem extends Actor {
         ReadPreference.primaryPreferred,
         "admin") // only "admin" DB for the admin command
 
-      val now = System.currentTimeMillis()
+      val now = timestamp()
 
       val updated = if (node.pingInfo.lastIsMasterId == -1) {
         // There is no IsMaster request waiting response for the node:

--- a/driver/src/main/scala/core/protocol/MongoHandler.scala
+++ b/driver/src/main/scala/core/protocol/MongoHandler.scala
@@ -13,6 +13,7 @@ import reactivemongo.io.netty.handler.timeout.IdleStateEvent
 import reactivemongo.core.actors.{ ChannelConnected, ChannelDisconnected }
 
 import reactivemongo.util.LazyLogger
+import reactivemongo.util.timestamp
 
 private[reactivemongo] class MongoHandler(
   supervisor: String,
@@ -26,7 +27,7 @@ private[reactivemongo] class MongoHandler(
   override def channelActive(ctx: ChannelHandlerContext): Unit = {
     log(ctx, "Channel is active")
 
-    last = System.currentTimeMillis()
+    last = timestamp()
 
     receiver ! ChannelConnected(ctx.channel.id)
 
@@ -35,7 +36,7 @@ private[reactivemongo] class MongoHandler(
 
   override def channelIdle(ctx: ChannelHandlerContext, e: IdleStateEvent) = {
     if (last != -1L) {
-      val now = System.currentTimeMillis()
+      val now = timestamp()
 
       log(ctx, s"Channel has been inactive for ${now - last} (last = $last)")
     }
@@ -46,7 +47,7 @@ private[reactivemongo] class MongoHandler(
   }
 
   override def channelInactive(ctx: ChannelHandlerContext): Unit = {
-    val now = System.currentTimeMillis()
+    val now = timestamp()
 
     if (last != -1) {
       val chan = ctx.channel
@@ -64,7 +65,7 @@ private[reactivemongo] class MongoHandler(
   }
 
   override def channelRead(ctx: ChannelHandlerContext, msg: Any): Unit = {
-    last = System.currentTimeMillis()
+    last = timestamp()
 
     msg match {
       case response: Response => {
@@ -88,7 +89,7 @@ private[reactivemongo] class MongoHandler(
     promise: ChannelPromise): Unit = {
     log(ctx, s"Channel is requested to write")
 
-    last = System.currentTimeMillis()
+    last = timestamp()
 
     super.write(ctx, msg, promise)
   }

--- a/driver/src/main/scala/core/protocol/MongoHandler.scala
+++ b/driver/src/main/scala/core/protocol/MongoHandler.scala
@@ -12,8 +12,7 @@ import reactivemongo.io.netty.handler.timeout.IdleStateEvent
 
 import reactivemongo.core.actors.{ ChannelConnected, ChannelDisconnected }
 
-import reactivemongo.util.LazyLogger
-import reactivemongo.util.timestamp
+import reactivemongo.util.{ LazyLogger, timestamp }
 
 private[reactivemongo] class MongoHandler(
   supervisor: String,

--- a/driver/src/main/scala/util/package.scala
+++ b/driver/src/main/scala/util/package.scala
@@ -28,6 +28,10 @@ import reactivemongo.core.errors.GenericDriverException
 package object util {
   import scala.language.implicitConversions
 
+  // timestamp in milliseconds (not related to any system or wall-clock time)
+  @inline
+  def timestamp(): Long = System.nanoTime() / 1000000
+
   /** Makes an option of the value matching the condition. */
   def option[T](cond: => Boolean, value: => T): Option[T] =
     if (cond) Some(value) else None

--- a/driver/src/test/scala/DatabaseSpec.scala
+++ b/driver/src/test/scala/DatabaseSpec.scala
@@ -4,6 +4,8 @@ import scala.concurrent.duration.FiniteDuration
 import reactivemongo.api.{ DefaultDB, FailoverStrategy, MongoConnection }
 import reactivemongo.api.commands.CommandError
 
+import reactivemongo.util.timestamp
+
 import org.specs2.concurrent.ExecutionEnv
 
 class DatabaseSpec(implicit ee: ExecutionEnv)
@@ -35,13 +37,13 @@ class DatabaseSpec(implicit ee: ExecutionEnv)
         val fos2 = FailoverStrategy(FiniteDuration(50, "ms"), 20,
           _ * 2 toDouble) // without accumulator
 
-        val before = System.currentTimeMillis()
+        val before = timestamp()
         val estmout = estTimeout(fos2)
 
         con.database("foo", fos1).map(_ => List.empty[Int]).
           recover({ case _ => ws.result() }) must beEqualTo(expected).
           await(0, estmout * 2) and {
-            val duration = System.currentTimeMillis() - before
+            val duration = timestamp() - before
 
             duration must be_<(estmout.toMillis + 2000 /* ms */ )
           }

--- a/driver/src/test/scala/DriverSpec.scala
+++ b/driver/src/test/scala/DriverSpec.scala
@@ -24,6 +24,7 @@ import reactivemongo.core.commands.{
 
 import reactivemongo.api.{ DefaultDB, FailoverStrategy }
 import reactivemongo.api.commands.DBUserRole
+import reactivemongo.util.timestamp
 
 import org.specs2.concurrent.ExecutionEnv
 
@@ -111,13 +112,13 @@ class DriverSpec(implicit ee: ExecutionEnv)
         List("foo:123"),
         DefaultOptions.copy(failoverStrategy = FailoverStrategy.remote))
 
-      val before = System.currentTimeMillis()
+      val before = timestamp()
       val unresolved = con.database(commonDb)
-      val after = System.currentTimeMillis()
+      val after = timestamp()
 
       (after - before) aka "invocation" must beBetween(0L, 75L) and {
         unresolved.map(_ => Option.empty[Throwable] -> -1L).recover {
-          case reason => Option(reason) -> (System.currentTimeMillis() - after)
+          case reason => Option(reason) -> (timestamp() - after)
         }.aka("duration") must beLike[(Option[Throwable], Long)] {
           case (Some(reason), duration) =>
             reason.getStackTrace.tail.headOption.

--- a/driver/src/test/scala/MonitorSpec.scala
+++ b/driver/src/test/scala/MonitorSpec.scala
@@ -13,6 +13,7 @@ import org.specs2.concurrent.ExecutionEnv
 import reactivemongo.core.actors.StandardDBSystem
 import reactivemongo.core.nodeset.{ Authenticate, Connection, Node }
 import reactivemongo.core.protocol.{ Response, ResponseInfo }
+import reactivemongo.util.timestamp
 
 import reactivemongo.api.{
   MongoConnection,
@@ -192,7 +193,7 @@ class MonitorSpec(implicit ee: ExecutionEnv)
       withConAndSys(options = opts) { (con, sysRef) =>
         @inline def dbsystem = sysRef.underlyingActor
 
-        //println(s"MonitorSpec_1: ${System.currentTimeMillis()}")
+        //println(s"MonitorSpec_1: ${timestamp()}")
 
         Future.successful(eventually(2, timeout) {
           isAvailable(con, timeout) must beTrue.await(0, timeout)
@@ -238,7 +239,7 @@ class MonitorSpec(implicit ee: ExecutionEnv)
             // so the incoming buffer is not read
             // (and so no isMaster response).
 
-            val before4 = System.currentTimeMillis()
+            val before4 = timestamp()
 
             connections1.headOption.foreach { con1 =>
               con1.channel.deregister()

--- a/driver/src/test/scala/UnresponsiveSecondarySpec.scala
+++ b/driver/src/test/scala/UnresponsiveSecondarySpec.scala
@@ -24,6 +24,8 @@ import reactivemongo.core.netty.ChannelBufferReadableBuffer
 
 import reactivemongo.io.netty.channel.{ Channel, DefaultChannelId }
 
+import reactivemongo.util.timestamp
+
 import _root_.tests.{ Common, NettyEmbedder }
 
 trait UnresponsiveSecondarySpec { parent: NodeSetSpec =>
@@ -86,7 +88,7 @@ trait UnresponsiveSecondarySpec { parent: NodeSetSpec =>
                     n.copy(pingInfo = n.pingInfo.copy(
                       lastIsMasterId = 1,
                       lastIsMasterTime = (
-                        System.currentTimeMillis() - PingInfo.pingTimeout)))
+                        timestamp() - PingInfo.pingTimeout)))
                   } else n
                 }
               }


### PR DESCRIPTION
Using the latter for measuring elapsed times is not a good idea since it relates
to a fixed point in time and takes adjustments of the system clock into
account (clock skew, NTP updates) so time may seem "to be running backwards".

The `System.nanoTime()` clock does not have this problem, at least since Java 8,
and is monotonically increasing (when supported by the OS).

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [x] Have you added tests for any changed functionality?

## Background Context

I think this might be related to a lot of "[node] hasn't answered in time to last ping! Please check its connectivity" errors we are seeing.

According to the server logs / statistics the connections were steady.

## References

https://docs.oracle.com/javase/8/docs/api/java/lang/System.html#nanoTime--

https://stackoverflow.com/questions/510462/is-system-nanotime-completely-useless/54566928#54566928

> Nonetheless, nanoTime() should still be preferred for implementing timed blocking, interval waiting, timeouts, etc. to currentTimeMillis() because the latter is a subject to the "time going backward" phenomenon (e. g. due to server time correction), i. e. currentTimeMillis() is not suitable for measuring time intervals at all.

https://stackoverflow.com/questions/510462/is-system-nanotime-completely-useless/54566928#54566928

> If you're just looking for extremely precise measurements of elapsed time, use System.nanoTime(). System.currentTimeMillis() will give you the most accurate possible elapsed time in milliseconds since the epoch, but System.nanoTime() gives you a nanosecond-precise time, relative to some arbitrary point.

http://vmnomad.blogspot.com/2015/09/esxi-and-guest-vm-time-sync-learning.html