### PR TITLE
Fixed zero-index UnwindField.productElement method

### DIFF
--- a/driver/src/main/scala/api/commands/AggregationFramework.scala
+++ b/driver/src/main/scala/api/commands/AggregationFramework.scala
@@ -479,7 +479,7 @@ trait AggregationFramework[P <: SerializationPack]
    * http://docs.mongodb.org/manual/reference/aggregation/unwind/#_S_unwind
    * @param field the name of the array to unwind
    */
-  case class UnwindField(field: String) extends Unwind(1, { case 1 => field },
+  case class UnwindField(field: String) extends Unwind(1, { case 0 => field },
     builder.document(Seq(
       builder.elementProducer(f"$$unwind", builder.string("$" + field)))))
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [ ] Have you added tests for any changed functionality?

## Fixes

Fixes #848

## Purpose
Changes the index of UnwindField.element from 1 to 0, to make it match the productElement contract and not break when invoking toString on it.

## Background Context

We have a custom logger, that logs the query and it invokes tostring on UnwindField.element. This internally breaks because productElement(0) is tried and fails. The Scala docs specify productElement to be 0-based, so for a one-element class, like UnwindField, the code block should work for 0.
