### PR TITLE
Fixes bson macro for non sealed trait families

### DIFF
--- a/macros/src/main/scala-2.10/MacroImpl.scala
+++ b/macros/src/main/scala-2.10/MacroImpl.scala
@@ -424,7 +424,7 @@ private object MacroImpl {
     private def classNameTree(tpe: Type): Option[c.Expr[(String, BSONString)]] = {
       val tpeSym = A.typeSymbol.asClass
 
-      if (tpeSym.isSealed && tpeSym.isAbstractClass) Some {
+      if (hasOption[Macros.Options.UnionType[_]] || tpeSym.isSealed && tpeSym.isAbstractClass) Some {
         val name = if (hasOption[Macros.Options.SaveSimpleName]) {
           c.literal(tpe.typeSymbol.name.decodedName.toString)
         } else c.literal(tpe.typeSymbol.fullName)

--- a/macros/src/main/scala-2.11/MacroImpl.scala
+++ b/macros/src/main/scala-2.11/MacroImpl.scala
@@ -352,7 +352,7 @@ private[bson] object MacroImpl {
     private def classNameTree(tpe: c.Type): Option[c.Expr[(String, BSONString)]] = {
       val tpeSym = A.typeSymbol.asClass
 
-      if (tpeSym.isSealed && tpeSym.isAbstract) Some {
+      if (hasOption[Macros.Options.UnionType[_]] || tpeSym.isSealed && tpeSym.isAbstract) Some {
         val name = if (hasOption[Macros.Options.SaveSimpleName]) {
           c.Expr[String](q"${tpe.typeSymbol.name.decodedName.toString}")
         } else c.Expr[String](q"${tpe.typeSymbol.fullName}")

--- a/macros/src/main/scala-2.12/MacroImpl.scala
+++ b/macros/src/main/scala-2.12/MacroImpl.scala
@@ -348,7 +348,7 @@ private[bson] object MacroImpl {
     private def classNameTree(tpe: c.Type): Option[c.Expr[(String, BSONString)]] = {
       val tpeSym = A.typeSymbol.asClass
 
-      if (tpeSym.isSealed && tpeSym.isAbstract) Some {
+      if (hasOption[Macros.Options.UnionType[_]] || tpeSym.isSealed && tpeSym.isAbstract) Some {
         val name = if (hasOption[Macros.Options.SaveSimpleName]) {
           c.Expr[String](q"${tpe.typeSymbol.name.decodedName.toString}")
         } else c.Expr[String](q"${tpe.typeSymbol.fullName}")

--- a/macros/src/main/scala-2.13/MacroImpl.scala
+++ b/macros/src/main/scala-2.13/MacroImpl.scala
@@ -348,7 +348,7 @@ private[bson] object MacroImpl {
     private def classNameTree(tpe: c.Type): Option[c.Expr[(String, BSONString)]] = {
       val tpeSym = A.typeSymbol.asClass
 
-      if (tpeSym.isSealed && tpeSym.isAbstract) Some {
+      if (hasOption[Macros.Options.UnionType[_]] || tpeSym.isSealed && tpeSym.isAbstract) Some {
         val name = if (hasOption[Macros.Options.SaveSimpleName]) {
           c.Expr[String](q"${tpe.typeSymbol.name.decodedName.toString}")
         } else c.Expr[String](q"${tpe.typeSymbol.fullName}")

--- a/macros/src/test/scala/MacroSpec.scala
+++ b/macros/src/test/scala/MacroSpec.scala
@@ -200,6 +200,20 @@ final class MacroSpec extends org.specs2.mutable.Specification {
         } and roundtrip(a, format) and roundtrip(b, format)
     }
 
+    "handle union types in non sealed trait" in {
+      import Union._
+      import Macros.Options._
+      val a = UA2(1)
+      val b = UB2("hai")
+      val format = Macros.handlerOpts[UT2, UnionType[UA2 \/ UB2] with AutomaticMaterialization]
+
+      format.write(a).getAs[String]("className").
+        aka("class #1") must beSome("MacroTest.Union.UA2") and {
+          format.write(b).getAs[String]("className").
+            aka("class #2") must beSome("MacroTest.Union.UB2")
+        } and roundtrip(a, format) and roundtrip(b, format)
+    }
+
     "handle union types (ADT) with simple names" in {
       import Union._
       import Macros.Options._

--- a/macros/src/test/scala/MacroSpec.scala
+++ b/macros/src/test/scala/MacroSpec.scala
@@ -200,7 +200,7 @@ final class MacroSpec extends org.specs2.mutable.Specification {
         } and roundtrip(a, format) and roundtrip(b, format)
     }
 
-    "handle union types in non sealed trait" in {
+    "handle union types as sealed family" in {
       import Union._
       import Macros.Options._
       val a = UA2(1)

--- a/macros/src/test/scala/MacroTest.scala
+++ b/macros/src/test/scala/MacroTest.scala
@@ -89,6 +89,10 @@ object MacroTest {
 
     case object DoNotExtendsA
     object DoNotExtendsB
+
+    trait UT2
+    case class UA2(n: Int) extends UT2
+    case class UB2(s: String) extends UT2
   }
 
   trait NestModule {


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [X] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [X] Have you added tests for any changed functionality?

## Fixes

Fixes bson macro for non sealed trait families, that was broken since https://github.com/ReactiveMongo/ReactiveMongo/pull/776

## Purpose

Make writing an non sealed trait family write the `className` field again.
The first commit demonstrates the problem via a testcase. The second commit fixes the issue.

## Background Context

I used the same approach used before. i.e use the `Macros.Options.UnionType[_]]` to decide if we should write the `className` field...

## References

https://github.com/ReactiveMongo/ReactiveMongo/pull/776