### PR TITLE
Fix random connection issues

### DIFF
--- a/driver/src/test/scala/ApiTesting.scala
+++ b/driver/src/test/scala/ApiTesting.scala
@@ -8,7 +8,7 @@ import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.concurrent.duration.{ FiniteDuration, SECONDS }
 
 import akka.util.Timeout
-import akka.actor.ActorRef
+import akka.actor.{ ActorRef, ActorRefFactory }
 
 import reactivemongo.io.netty.channel.{
   Channel,
@@ -148,7 +148,8 @@ package object tests {
   @inline def connectAll(sys: StandardDBSystem, ns: NodeSet) =
     sys.connectAll(ns)
 
-  @inline def channelFactory(supervisorName: String, connectionName: String, options: MongoConnectionOptions): ChannelFactory = new ChannelFactory(supervisorName, connectionName, options)
+  @inline def channelFactory(supervisorName: String, connectionName: String, options: MongoConnectionOptions)(implicit arf: ActorRefFactory): ChannelFactory =
+    new ChannelFactory(supervisorName, connectionName, options)
 
   @inline def createChannel(
     factory: ChannelFactory,


### PR DESCRIPTION
## Purpose

On fast machines with lots of cores, the Channel initialization function was often unreliable; `initChannel()` was being called at the same time that the channel properties were being added as attributes.

Fix by creating an actor to hold the properties for new channels, and stash requests for a channel's properties until after they've been added to the temporary cache.

## Background Context

An actor seemed like the natural way of dealing with this issue. I had to add an `Await` to fulfill Netty's blocking initialize interface.

## References

https://groups.google.com/forum/?fromgroups=#!topic/reactivemongo/LJrpobGsbJM
