### PR TITLE
Fix/fix bulk byte size

### DIFF
--- a/bson/src/main/scala-2.13+/types.scala
+++ b/bson/src/main/scala-2.13+/types.scala
@@ -908,7 +908,7 @@ sealed trait BSONElementSet extends ElementProducer { self: BSONValue =>
   override private[reactivemongo] lazy val byteSize: Int =
     elements.foldLeft(5) {
       case (sz, BSONElement(n, v)) =>
-        sz + 2 + n.getBytes.size + v.byteSize
+        sz + BSONElementSet.docElementByteOverhead + n.getBytes.size + v.byteSize
     }
 }
 
@@ -920,6 +920,8 @@ object BSONElementSet {
   implicit def apply(set: Iterable[BSONElement]): BSONElementSet =
     new BSONDocument(set.map(Success(_)).toStream)
 
+  // key null terminator + type prefix for the element
+  private[reactivemongo] val docElementByteOverhead = 2
 }
 
 /**

--- a/bson/src/main/scala-2.13-/types.scala
+++ b/bson/src/main/scala-2.13-/types.scala
@@ -907,7 +907,7 @@ sealed trait BSONElementSet extends ElementProducer { self: BSONValue =>
   override private[reactivemongo] lazy val byteSize: Int =
     elements.foldLeft(5) {
       case (sz, BSONElement(n, v)) =>
-        sz + BSONElementSet.typePrefixByteSize + n.getBytes.size + v.byteSize
+        sz + BSONElementSet.docElementByteOverhead + n.getBytes.size + v.byteSize
     }
 }
 
@@ -919,7 +919,8 @@ object BSONElementSet {
   implicit def apply(set: Traversable[BSONElement]): BSONElementSet =
     new BSONDocument(set.map(Success(_)).toStream)
 
-  private[reactivemongo] val typePrefixByteSize = 2
+  // key null terminator + type prefix for the element
+  private[reactivemongo] val docElementByteOverhead = 2
 }
 
 /**

--- a/bson/src/main/scala-2.13-/types.scala
+++ b/bson/src/main/scala-2.13-/types.scala
@@ -907,7 +907,7 @@ sealed trait BSONElementSet extends ElementProducer { self: BSONValue =>
   override private[reactivemongo] lazy val byteSize: Int =
     elements.foldLeft(5) {
       case (sz, BSONElement(n, v)) =>
-        sz + 2 + n.getBytes.size + v.byteSize
+        sz + BSONElementSet.typePrefixByteSize + n.getBytes.size + v.byteSize
     }
 }
 
@@ -919,6 +919,7 @@ object BSONElementSet {
   implicit def apply(set: Traversable[BSONElement]): BSONElementSet =
     new BSONDocument(set.map(Success(_)).toStream)
 
+  private[reactivemongo] val typePrefixByteSize = 2
 }
 
 /**

--- a/driver/src/main/scala/api/collections/BulkOps.scala
+++ b/driver/src/main/scala/api/collections/BulkOps.scala
@@ -71,7 +71,7 @@ private[reactivemongo] object BulkOps {
           Left(s"size of document #${offset + docs} exceed the maxBsonSize: $bsz + 3 > $maxBsonSize")
         } else {
           val nc = docs + 1
-          val nsz = bsonSize + bsz
+          val nsz = bsonSize + bsz + docs.toString.getBytes.length + BSONElementSet.typePrefixByteSize
 
           if (nsz > maxBsonSize) {
             Right(BulkStage[I](

--- a/driver/src/main/scala/api/collections/BulkOps.scala
+++ b/driver/src/main/scala/api/collections/BulkOps.scala
@@ -68,7 +68,7 @@ private[reactivemongo] object BulkOps {
 
         // Total minimal size is key '1' size (1 byte) + type prefix (2 bytes)
         if (bsz + 1 + BSONElementSet.typePrefixByteSize > maxBsonSize) {
-          Left(s"size of document #${offset + docs} exceed the maxBsonSize: $bsz > $maxBsonSize")
+          Left(s"size of document #${offset + docs} exceed the maxBsonSize: $bsz + 3 > $maxBsonSize")
         } else {
           val nc = docs + 1
           val nsz = bsonSize + bsz

--- a/driver/src/main/scala/api/collections/BulkOps.scala
+++ b/driver/src/main/scala/api/collections/BulkOps.scala
@@ -2,6 +2,7 @@ package reactivemongo.api.collections
 
 import scala.concurrent.{ ExecutionContext, Future }
 
+import reactivemongo.bson.BSONElementSet
 import reactivemongo.core.errors.GenericDriverException
 
 /** Internal bulk operations */
@@ -66,7 +67,7 @@ private[reactivemongo] object BulkOps {
         val bsz = sz(doc)
 
         // Total minimal size is key '1' size (1 byte) + type prefix (2 bytes)
-        if (bsz + 1 + 2 > maxBsonSize) {
+        if (bsz + 1 + BSONElementSet.typePrefixByteSize > maxBsonSize) {
           Left(s"size of document #${offset + docs} exceed the maxBsonSize: $bsz > $maxBsonSize")
         } else {
           val nc = docs + 1

--- a/driver/src/main/scala/api/collections/BulkOps.scala
+++ b/driver/src/main/scala/api/collections/BulkOps.scala
@@ -65,7 +65,8 @@ private[reactivemongo] object BulkOps {
       case Some(doc) => {
         val bsz = sz(doc)
 
-        if (bsz > maxBsonSize) {
+        // Total minimal size is key '1' size (1 byte) + type prefix (2 bytes)
+        if (bsz + 1 + 2 > maxBsonSize) {
           Left(s"size of document #${offset + docs} exceed the maxBsonSize: $bsz > $maxBsonSize")
         } else {
           val nc = docs + 1

--- a/driver/src/main/scala/api/collections/BulkOps.scala
+++ b/driver/src/main/scala/api/collections/BulkOps.scala
@@ -71,7 +71,8 @@ private[reactivemongo] object BulkOps {
           Left(s"size of document #${offset + docs} exceed the maxBsonSize: $bsz + 3 > $maxBsonSize")
         } else {
           val nc = docs + 1
-          val nsz = bsonSize + bsz + docs.toString.getBytes.length + BSONElementSet.typePrefixByteSize
+          val keySize = docs.toString.getBytes.size // string repr. of current index used as key
+          val nsz = bsonSize + bsz + keySize + BSONElementSet.typePrefixByteSize
 
           if (nsz > maxBsonSize) {
             Right(BulkStage[I](

--- a/driver/src/main/scala/api/collections/BulkOps.scala
+++ b/driver/src/main/scala/api/collections/BulkOps.scala
@@ -67,12 +67,12 @@ private[reactivemongo] object BulkOps {
         val bsz = sz(doc)
 
         // Total minimal size is key '1' size (1 byte) + type prefix (2 bytes)
-        if (bsz + 1 + BSONElementSet.typePrefixByteSize > maxBsonSize) {
+        if (bsz + 1 + BSONElementSet.docElementByteOverhead > maxBsonSize) {
           Left(s"size of document #${offset + docs} exceed the maxBsonSize: $bsz + 3 > $maxBsonSize")
         } else {
           val nc = docs + 1
           val keySize = docs.toString.getBytes.size // string repr. of current index used as key
-          val nsz = bsonSize + bsz + keySize + BSONElementSet.typePrefixByteSize
+          val nsz = bsonSize + bsz + keySize + BSONElementSet.docElementByteOverhead
 
           if (nsz > maxBsonSize) {
             Right(BulkStage[I](

--- a/driver/src/test/scala/BulkOpsSpec.scala
+++ b/driver/src/test/scala/BulkOpsSpec.scala
@@ -91,10 +91,11 @@ class BulkOpsSpec(implicit ee: ExecutionEnv)
     s"take into account the fact that keys increase in size in a larger array" in {
       val ExpectedFirstBulk = Iterator.continually(doc1).take(10).toList
       val ExpectedSecondBulk = List(doc1)
+      val enoughSizeWithoutConsideringSizeIncrease = (doc1.byteSize + 1 + BSONElementSet.typePrefixByteSize) * 11
 
       bulks[BSONDocument](
         documents = Iterator.continually(doc1).take(11).toSeq,
-        maxBsonSize = (doc1.byteSize + 1 + BSONElementSet.typePrefixByteSize) * 11,
+        maxBsonSize = enoughSizeWithoutConsideringSizeIncrease,
         maxBulkSize = 11)(_.byteSize) must beLike[BulkProducer[BSONDocument]] {
         case prod1 =>
           prod1() must beRight.like {

--- a/driver/src/test/scala/BulkOpsSpec.scala
+++ b/driver/src/test/scala/BulkOpsSpec.scala
@@ -53,7 +53,7 @@ class BulkOpsSpec(implicit ee: ExecutionEnv)
             case BulkStage(bulk1, Some(prod2)) =>
               bulk1.toList must_== List(doc1, doc1) and {
                 prod2() must beLeft(
-                  s"size of document #2 exceed the maxBsonSize: ${doc2.byteSize} > ${bsonSize1}")
+                  s"size of document #2 exceed the maxBsonSize: ${doc2.byteSize} + 3 > ${bsonSize1}")
               }
           }
         }
@@ -78,7 +78,7 @@ class BulkOpsSpec(implicit ee: ExecutionEnv)
       }
     }
 
-    s"take key size into account into total size" in {
+    s"take minimal size into account into total size" in {
       bulks[BSONDocument](
         documents = producer2Docs,
         maxBsonSize = doc1.byteSize,
@@ -87,6 +87,7 @@ class BulkOpsSpec(implicit ee: ExecutionEnv)
           prod1() must beLeft
       }
     }
+
   }
 
   "Application" should {

--- a/driver/src/test/scala/BulkOpsSpec.scala
+++ b/driver/src/test/scala/BulkOpsSpec.scala
@@ -78,7 +78,7 @@ class BulkOpsSpec(implicit ee: ExecutionEnv)
       }
     }
 
-    s"take minimal size into account into total size" in {
+    "take minimal size into account into total size" in {
       bulks[BSONDocument](
         documents = producer2Docs,
         maxBsonSize = doc1.byteSize,
@@ -88,13 +88,13 @@ class BulkOpsSpec(implicit ee: ExecutionEnv)
       }
     }
 
-    s"take into account the fact that keys increase in size in a larger array" in {
-      val ExpectedFirstBulk = Iterator.continually(doc1).take(10).toList
+    "take into account the fact that keys increase in size in a larger array" in {
+      val ExpectedFirstBulk = List.fill(10)(doc1)
       val ExpectedSecondBulk = List(doc1)
       val enoughSizeWithoutConsideringSizeIncrease = (doc1.byteSize + 1 + BSONElementSet.typePrefixByteSize) * 11
 
       bulks[BSONDocument](
-        documents = Iterator.continually(doc1).take(11).toSeq,
+        documents = Seq.fill(11)(doc1),
         maxBsonSize = enoughSizeWithoutConsideringSizeIncrease,
         maxBulkSize = 11)(_.byteSize) must beLike[BulkProducer[BSONDocument]] {
         case prod1 =>


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [x] Have you added tests for any changed functionality?

## Fixes

Probably fixes #871 

## Purpose

Correctly compute a bulk size in BulkOps. 

Currently we do not account for the total array size of a bulk. This means that a small errors adds up in our expected byte size for each document. This ultimately makes Reactive mongo send a bulk insert command which is too big.

## Background Context
When running a bulk operation, reactive mongo cuts the Seq of documents to insert (for instance) in bulks to avoid sending a command which is bigger than the maximum byte size allowed by MongoDB. But the way we compute the bulk size seems wrong. 

**Example:** 
Say we want to insert 3 empty documents: `[{},{},{}]` . Currently we compute the size by adding the size of an empty doc 3 times, but the real bulk size is the size of the complete array`[{},{},{}]`. 

This means that we can potentially send a command over the size limit.

A BSONArray is like a BSONDocument with numeric key according to the spec [1] : `[ {}, {}, {} ] <=> { '0': {}, '1': {}, '2': {}}`. This means that when computing the size of a bulk we must also add : 
 - The type prefix : 2 bytes
 - The size of the "key", which increase as the array gets bigger (The 11th element cost actually more bytes than the first because the key '10' take two bytes)

## References

[1] http://bsonspec.org/spec.html
