### PR TITLE
log native netty loading success

### DIFF
--- a/driver/src/main/scala/core/netty/Pack.scala
+++ b/driver/src/main/scala/core/netty/Pack.scala
@@ -37,8 +37,10 @@ private[core] object Pack {
       val groupClass = Class.forName(s"${kqueuePkg}.KQueueEventLoopGroup").
         asInstanceOf[Class[_ <: EventLoopGroup]]
 
-      new Pack(() =>
+      val pack = new Pack(() =>
         groupClass.getDeclaredConstructor().newInstance(), chanClass)
+      logger.info("Netty KQueue successfully loaded")
+      pack
     }
   } catch {
     case cause: Exception =>
@@ -55,8 +57,10 @@ private[core] object Pack {
       val groupClass = Class.forName(s"${epollPkg}.EpollEventLoopGroup").
         asInstanceOf[Class[_ <: EventLoopGroup]]
 
-      new Pack(() =>
+      val pack = new Pack(() =>
         groupClass.getDeclaredConstructor().newInstance(), chanClass)
+      logger.info("Netty EPoll successfully loaded")
+      pack
     }
   } catch {
     case cause: Exception =>


### PR DESCRIPTION
It's a reassuring thing to see on production.
Logging as "info" to avoid having to set the production root logger to "debug".
