### PR TITLE
Fix summoning of BSONHandler[Seq[Int]]

### DIFF
--- a/bson/src/main/scala/DefaultBSONHandlers.scala
+++ b/bson/src/main/scala/DefaultBSONHandlers.scala
@@ -159,7 +159,7 @@ trait DefaultBSONHandlers extends LowPrioBSONHandlers {
     def write(b: BSONJavaScript) = b
   }
 
-  implicit def findWriter[T](implicit writer: VariantBSONWriter[T, _ <: BSONValue]): BSONWriter[T, _ <: BSONValue] =
+  implicit def findWriter[T, B <: BSONValue](implicit writer: VariantBSONWriter[T, B]): BSONWriter[T, B] =
     new VariantBSONWriterWrapper(writer)
 
   implicit def MapReader[K, V](implicit keyReader: BSONReader[BSONString, K], valueReader: BSONReader[_ <: BSONValue, V]): BSONDocumentReader[Map[K, V]] =

--- a/bson/src/test/scala/HandlerSpec.scala
+++ b/bson/src/test/scala/HandlerSpec.scala
@@ -17,8 +17,9 @@ package reactivemongo.bson
  * limitations under the License.
  */
 import java.util.Date
+import org.specs2.execute._, Typecheck._
 
-class HandlerSpec extends org.specs2.mutable.Specification {
+class HandlerSpec extends org.specs2.mutable.Specification with org.specs2.matcher.TypecheckMatchers {
   "Handler" title
 
   section("unit")
@@ -280,6 +281,14 @@ class HandlerSpec extends org.specs2.mutable.Specification {
       val h = implicitly[BSONHandler[BSONString, Foo]]
 
       h.write(foo) must_=== bson and (h.read(bson) must_=== foo)
+    }
+  }
+
+  "BSONHandler" should {
+    "summon Seq instance" in {
+      typecheck {
+        "implicitly[BSONHandler[BSONArray, Seq[Int]]]"
+      }
     }
   }
 

--- a/project/Bson.scala
+++ b/project/Bson.scala
@@ -30,6 +30,7 @@ class Bson() {
       libraryDependencies ++= shaded.value ++ Seq(
         specs.value,
         "org.specs2" %% "specs2-scalacheck" % specsVer.value % Test,
+        "org.specs2" %% "specs2-matcher-extra" % specsVer.value % Test,
         discipline.value % Test,
         "org.typelevel" %% "spire-laws" % spireLawsVer.value % Test),
       mimaBinaryIssueFilters ++= {


### PR DESCRIPTION
## Fixes

Fixes implicit resolution of `BSONHandler[Seq[Int]]` due to a problem in `reactivemongo.bson.DefaultBSONHandlers#findWriter`
