### PR TITLE
[WIP] Send the correct bulk of updates in BulkOps

### DIFF
--- a/driver/src/main/scala/api/collections/UpdateOps.scala
+++ b/driver/src/main/scala/api/collections/UpdateOps.scala
@@ -179,7 +179,7 @@ trait UpdateOps[P <: SerializationPack] extends UpdateCommand[P]
 
         BulkOps.bulkApply[UpdateElement, UpdateWriteResult](
           bulkProducer)({ bulk =>
-          execute(first, bulk.drop(1).toSeq)
+          execute(bulk.headOption.getOrElse(first), bulk.drop(1).toSeq)
         }, bulkRecover).map(MultiBulkWriteResult(_))
       }
 

--- a/driver/src/test/scala/UpdateSpec.scala
+++ b/driver/src/test/scala/UpdateSpec.scala
@@ -10,7 +10,7 @@ import _root_.tests.Common
 
 import reactivemongo.api.tests.{ builder, decoder, pack, reader, writer }
 
-import scala.concurrent.{ Await, Future }
+import scala.concurrent.Future
 
 trait UpdateSpec extends UpdateFixtures { collectionSpec: CollectionSpec =>
   import reactivemongo.api.TestCompat._
@@ -76,7 +76,7 @@ trait UpdateSpec extends UpdateFixtures { collectionSpec: CollectionSpec =>
                 BSONDocument(
                   "id" -> BSONString(s"child${num}"),
                   "value" -> BSONString("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")))
-      
+
       def upsertElements(collection: DefaultCollection, documents: List[TestDocument]) = {
         val updateBuilder = collection.update(ordered = false)
         val updateElements = Future.sequence(
@@ -94,14 +94,14 @@ trait UpdateSpec extends UpdateFixtures { collectionSpec: CollectionSpec =>
 
       val childrenPerElement = 200 * 1000
       val documents = List(
-        TestDocument("id1", createChildDocuments(childrenPerElement)),
-        TestDocument("id2", createChildDocuments(childrenPerElement)))
+        TestDocument(System.nanoTime().toString, createChildDocuments(childrenPerElement)),
+        TestDocument(System.nanoTime().toString, createChildDocuments(childrenPerElement)))
 
-      val writeResult = Await.result(upsertElements(updCol2, documents), timeout)
+      val writeResult = upsertElements(updCol2, documents)
 
       val expectedDocumentsNumber = documents.size
-      writeResult.totalN must beTypedEqualTo(expectedDocumentsNumber) and {
-        writeResult.nModified must beTypedEqualTo(expectedDocumentsNumber)
+      writeResult.map(_.totalN) must beTypedEqualTo(expectedDocumentsNumber).await(1, timeout) and {
+        writeResult.map(_.nModified) must beTypedEqualTo(expectedDocumentsNumber).await(1, timeout)
       }
     }
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #xxxx

## Purpose

Send the correct bulk of updates in BulkOps.

## Background Context

Currently, we drop the first element of a bulk, assuming that it is passed as the first parameter to the `execute` method, however, what is passed as the first parameter is the first element of the whole sequence:
```
final def many(updates: Iterable[UpdateElement])(...) = updates.headOption match {
      case Some(first) => {
        val bulkProducer = BulkOps.bulks(
          updates, maxBsonSize, metadata.maxBulkSize) { up =>
          elementEnvelopeSize + pack.bsonSize(up.q) + pack.bsonSize(up.u)
        }

        BulkOps.bulkApply[UpdateElement, UpdateWriteResult](
          bulkProducer)({ bulk =>
          execute(first, bulk.drop(1).toSeq)                     // This is the problematic line 
        }, bulkRecover).map(MultiBulkWriteResult(_))
      }
```
### Example

Let's say, our updates are `[docA, docB, docC, docD]` and they're divided into 3 bulks `[[docA], [docB, docC], [docD]]`. Then code above will result in 3 calls to `execute`: `execute(docA, [])`, `execute(docA, [docC])`,  `execute(docA, [])`, i.e. `docB` and `docD` will never be written to mongo.

### Impact

1. We lose the first element of every bulk starting from the second bulk.
2. The bulk size is no longer correct because the first element of the whole updates sequence can be smaller or bigger than the first element of the bulk. 

> Why did you take this approach?

This is the simplest way to fix the issue. All other solutions / suggestions are welcomed.

## References

No
