### PR TITLE
[WIP] Process all items in the bulk update request

### DIFF
--- a/driver/src/main/scala/api/collections/UpdateOps.scala
+++ b/driver/src/main/scala/api/collections/UpdateOps.scala
@@ -179,7 +179,7 @@ trait UpdateOps[P <: SerializationPack] extends UpdateCommand[P]
 
         BulkOps.bulkApply[UpdateElement, UpdateWriteResult](
           bulkProducer)({ bulk =>
-          execute(first, bulk.drop(1).toSeq)
+          execute(bulk.headOption.getOrElse(first), bulk.drop(1).toSeq)
         }, bulkRecover).map(MultiBulkWriteResult(_))
       }
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [ ] Have you added tests for any changed functionality?

## Fixes

Fixes the issue, reported in https://github.com/ReactiveMongo/ReactiveMongo/pull/991

## Purpose

Send the correct bulk of updates in BulkOps.

## Background Context

Currently, we drop the first element of every bulk, wrongly assuming that it is passed as the first parameter to the `execute` method. This pull request fixes the issue by passing the first element of the bulk, when exists, to `execute`.

## References

- https://github.com/ReactiveMongo/ReactiveMongo/pull/991
