### PR TITLE
Fix idle connection disposal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ commands:
     parameters:
       sbt_version:
         type: string
-        default: "1.4.7"
+        default: "1.5.2"
     steps:
       - restore_cache:
           name: Restore SBT cache
@@ -48,7 +48,7 @@ commands:
       - restore_cache:
           name: Restore Scala cache
           keys:
-            - &scala_cache_key scala-{{ .Environment.CIRCLE_JOB }}-<< parameters.shaded >>-{{ checksum "version.sbt" }}-{{ checksum "build.sbt" }}-{{ checksum "project/Common.scala" }}-{{ checksum "project/Dependencies.scala" }}
+            - &scala_cache_key scala-{{ .Environment.CIRCLE_JOB }}-<< parameters.shaded >>-{{ checksum "version.sbt" }}_{{ checksum "build.sbt" }}-{{ checksum "project/Common.scala" }}-{{ checksum "project/Dependencies.scala" }}
 
       - restore_cache:
           name: Restore compilation cache

--- a/driver/src/main/scala/core/netty/ChannelFactory.scala
+++ b/driver/src/main/scala/core/netty/ChannelFactory.scala
@@ -1,22 +1,43 @@
 package reactivemongo.core.netty
 
 import java.lang.{ Boolean => JBool }
+
 import java.util.concurrent.TimeUnit
+
 import scala.util.{ Failure, Success, Try }
+
 import scala.concurrent.Promise
 
 import reactivemongo.io.netty.util.concurrent.{ Future, GenericFutureListener }
+
 import reactivemongo.io.netty.bootstrap.Bootstrap
-import reactivemongo.io.netty.channel.{ Channel, ChannelFuture, ChannelFutureListener, ChannelOption, EventLoopGroup }
-import ChannelOption.{ CONNECT_TIMEOUT_MILLIS, SO_KEEPALIVE, TCP_NODELAY }
+
+import reactivemongo.io.netty.channel.{
+  Channel,
+  ChannelFuture,
+  ChannelFutureListener,
+  ChannelOption,
+  EventLoopGroup
+}, ChannelOption.{ CONNECT_TIMEOUT_MILLIS, SO_KEEPALIVE, TCP_NODELAY }
+
 import reactivemongo.io.netty.channel.ChannelInitializer
+
+import reactivemongo.io.netty.handler.timeout.IdleStateHandler
+
 import akka.actor.ActorRef
+
 import reactivemongo.util.LazyLogger
-import reactivemongo.core.protocol.{ MongoHandler, RequestEncoder, ResponseDecoder, ResponseFrameDecoder }
+
+import reactivemongo.core.protocol.{
+  MongoHandler,
+  RequestEncoder,
+  ResponseFrameDecoder,
+  ResponseDecoder
+}
 import reactivemongo.core.actors.ChannelDisconnected
 import reactivemongo.core.errors.GenericDriverException
+
 import reactivemongo.api.MongoConnectionOptions
-import reactivemongo.io.netty.handler.timeout.IdleStateHandler
 
 /**
  * @param supervisor the name of the driver supervisor

--- a/driver/src/main/scala/core/netty/ChannelFactory.scala
+++ b/driver/src/main/scala/core/netty/ChannelFactory.scala
@@ -1,39 +1,22 @@
 package reactivemongo.core.netty
 
 import java.lang.{ Boolean => JBool }
-
+import java.util.concurrent.TimeUnit
 import scala.util.{ Failure, Success, Try }
-
 import scala.concurrent.Promise
 
 import reactivemongo.io.netty.util.concurrent.{ Future, GenericFutureListener }
-
 import reactivemongo.io.netty.bootstrap.Bootstrap
-
-import reactivemongo.io.netty.channel.{
-  Channel,
-  ChannelFuture,
-  ChannelFutureListener,
-  ChannelOption,
-  EventLoopGroup
-}, ChannelOption.{ CONNECT_TIMEOUT_MILLIS, SO_KEEPALIVE, TCP_NODELAY }
-
+import reactivemongo.io.netty.channel.{ Channel, ChannelFuture, ChannelFutureListener, ChannelOption, EventLoopGroup }
+import ChannelOption.{ CONNECT_TIMEOUT_MILLIS, SO_KEEPALIVE, TCP_NODELAY }
 import reactivemongo.io.netty.channel.ChannelInitializer
-
 import akka.actor.ActorRef
-
 import reactivemongo.util.LazyLogger
-
-import reactivemongo.core.protocol.{
-  MongoHandler,
-  RequestEncoder,
-  ResponseFrameDecoder,
-  ResponseDecoder
-}
+import reactivemongo.core.protocol.{ MongoHandler, RequestEncoder, ResponseDecoder, ResponseFrameDecoder }
 import reactivemongo.core.actors.ChannelDisconnected
 import reactivemongo.core.errors.GenericDriverException
-
 import reactivemongo.api.MongoConnectionOptions
+import reactivemongo.io.netty.handler.timeout.IdleStateHandler
 
 /**
  * @param supervisor the name of the driver supervisor
@@ -114,22 +97,20 @@ private[reactivemongo] final class ChannelFactory(
 
     val pipeline = channel.pipeline
 
+    val idleTimeMS = options.maxIdleTimeMS.toLong
+    pipeline.addLast("idleState", new IdleStateHandler(idleTimeMS, idleTimeMS, 0, TimeUnit.MILLISECONDS))
+
     if (options.sslEnabled) {
-      val sslEng = reactivemongo.core.SSL.
-        createEngine(sslContext, host, port)
-
-      val sslHandler =
-        new reactivemongo.io.netty.handler.ssl.SslHandler(sslEng, false /* TLS */ )
-
-      pipeline.addFirst("ssl", sslHandler)
+      val sslEng = reactivemongo.core.SSL.createEngine(sslContext, host, port)
+      val sslHandler = new reactivemongo.io.netty.handler.ssl.SslHandler(sslEng, false /* TLS */ )
+      pipeline.addLast("ssl", sslHandler)
     }
 
-    val mongoHandler = new MongoHandler(
-      supervisor, connection, receiver, options.maxIdleTimeMS.toLong)
-
     pipeline.addLast(
-      new ResponseFrameDecoder(), new ResponseDecoder(),
-      new RequestEncoder(), mongoHandler)
+      new ResponseFrameDecoder(),
+      new ResponseDecoder(),
+      new RequestEncoder(),
+      new MongoHandler(supervisor, connection, receiver))
 
     trace(s"Netty channel configuration:\n- connectTimeoutMS: ${options.connectTimeoutMS}\n- maxIdleTimeMS: ${options.maxIdleTimeMS}ms\n- tcpNoDelay: ${options.tcpNoDelay}\n- keepAlive: ${options.keepAlive}\n- sslEnabled: ${options.sslEnabled}\n- keyStore: ${options.keyStore.fold("None")(_.toString)}")
   }

--- a/driver/src/main/scala/core/protocol/MongoHandler.scala
+++ b/driver/src/main/scala/core/protocol/MongoHandler.scala
@@ -1,17 +1,13 @@
 package reactivemongo.core.protocol
 
-import java.util.concurrent.TimeUnit
-
 import akka.actor.ActorRef
 
 import reactivemongo.io.netty.channel.{
   ChannelHandlerContext,
+  ChannelDuplexHandler,
   ChannelPromise
 }
-import reactivemongo.io.netty.handler.timeout.{
-  IdleStateEvent,
-  IdleStateHandler
-}
+import reactivemongo.io.netty.handler.timeout.IdleStateEvent
 
 import reactivemongo.core.actors.{ ChannelConnected, ChannelDisconnected }
 
@@ -20,9 +16,7 @@ import reactivemongo.util.LazyLogger
 private[reactivemongo] class MongoHandler(
   supervisor: String,
   connection: String,
-  receiver: ActorRef,
-  idleTimeMS: Long) extends IdleStateHandler(
-  idleTimeMS, idleTimeMS, idleTimeMS, TimeUnit.MILLISECONDS) {
+  receiver: ActorRef) extends ChannelDuplexHandler {
 
   private var last: Long = -1L // in nano-precision
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [ ] Have you added tests for any changed functionality?

## Fixes

Fixes an issue described in: https://groups.google.com/g/reactivemongo/c/3Kb-tpAcO6Y

## Purpose

Fixes idle connection disposal.

## Background Context

The `IdleStateHandler` should be set as first in the netty's pipeline (according to the documentation). This was not true if SSL was enabled.

## References

* Described issue with code to reproduce: https://groups.google.com/g/reactivemongo/c/3Kb-tpAcO6Y
* Netty's docs: https://netty.io/4.0/api/io/netty/handler/timeout/IdleStateHandler.html
