### PR TITLE
Closes #1096

### DIFF
--- a/driver/src/main/scala/api/commands/DeleteCommand.scala
+++ b/driver/src/main/scala/api/commands/DeleteCommand.scala
@@ -13,7 +13,7 @@ import reactivemongo.api.{
  */
 private[reactivemongo] trait DeleteCommand[P <: SerializationPack] { self: PackSupport[P] =>
 
-  private[api] final class Delete(
+  private[reactivemongo] final class Delete(
     val deletes: Seq[DeleteElement],
     val ordered: Boolean,
     val writeConcern: WriteConcern) extends CollectionCommand with CommandWithResult[DeleteResult] {
@@ -21,7 +21,7 @@ private[reactivemongo] trait DeleteCommand[P <: SerializationPack] { self: PackS
   }
 
   /** Delete command element */
-  final class DeleteElement private[api] (
+  final class DeleteElement private[reactivemongo] (
     _q: pack.Document,
     _limit: Int,
     _collation: Option[Collation]) {
@@ -53,11 +53,11 @@ private[reactivemongo] trait DeleteCommand[P <: SerializationPack] { self: PackS
   /** Result for a delete command */
   final type DeleteResult = DefaultWriteResult
 
-  protected final type DeleteCmd = ResolvedCollectionCommand[Delete]
+  protected[reactivemongo] final type DeleteCmd = ResolvedCollectionCommand[Delete]
 
   private[reactivemongo] def session(): Option[Session]
 
-  protected final implicit lazy val deleteWriter: pack.Writer[DeleteCmd] =
+  protected[reactivemongo] final implicit lazy val deleteWriter: pack.Writer[DeleteCmd] =
     deleteWriter(self.session())
 
   protected final def deleteWriter(
@@ -84,7 +84,7 @@ private[reactivemongo] trait DeleteCommand[P <: SerializationPack] { self: PackS
       delete.command.deletes.headOption.foreach { first =>
         elements += element("deletes", builder.array(
           writeElement(builder, first) +:
-            delete.command.deletes.map(writeElement(builder, _))))
+            delete.command.deletes.tail.map(writeElement(builder, _))))
       }
 
       builder.document(elements.result())

--- a/driver/src/test/scala/DeleteCommandSpec.scala
+++ b/driver/src/test/scala/DeleteCommandSpec.scala
@@ -1,6 +1,5 @@
 package reactivemongo
 
-import reactivemongo.api.bson.BSONDocument.pretty
 import reactivemongo.api.bson.{ BSONArray, BSONDocument }
 import reactivemongo.api.commands.{ DeleteCommand, ResolvedCollectionCommand }
 import reactivemongo.api.{ PackSupport, Session, WriteConcern }

--- a/driver/src/test/scala/DeleteCommandSpec.scala
+++ b/driver/src/test/scala/DeleteCommandSpec.scala
@@ -1,0 +1,67 @@
+package reactivemongo
+
+import reactivemongo.api.bson.BSONDocument.pretty
+import reactivemongo.api.bson.{ BSONArray, BSONDocument }
+import reactivemongo.api.commands.{ DeleteCommand, ResolvedCollectionCommand }
+import reactivemongo.api.{ PackSupport, Session, WriteConcern }
+
+final class DeleteCommandSpec extends org.specs2.mutable.Specification {
+  "Delete command".title
+
+  section("unit")
+  "Delete command" should {
+    "be written" >> {
+
+      val base: BSONDocument = BSONDocument(
+        "delete" -> "foo",
+        "ordered" -> true)
+
+      val writeConcern = BSONDocument(
+        "writeConcern" -> BSONDocument(
+          "w" -> 1,
+          "j" -> false))
+
+      def deletes(xs: Seq[BSONDocument]): BSONDocument = BSONDocument(
+        "deletes" -> BSONArray(xs))
+
+      // ---
+
+      "with correct `deletes` elements" in {
+        val cmd = new Command(None)
+        val element = new cmd.DeleteElement(
+          _q = BSONDocument("_id" -> 1),
+          _limit = 1,
+          _collation = None)
+        val bson = BSONDocument(
+          "q" -> BSONDocument("_id" -> 1),
+          "limit" -> 1)
+
+        withDelete(cmd)(element :: Nil) { delete =>
+          cmd.pack.serialize(delete, cmd.deleteWriter) must_=== (base ++ writeConcern ++ deletes(bson :: Nil))
+        }
+      }
+    }
+  }
+  section("unit")
+
+  // ---
+
+  private def withDelete[T](cmd: Command)(deletes: Seq[cmd.DeleteElement])(f: cmd.DeleteCmd => T): T = {
+    f(new ResolvedCollectionCommand(
+      collection = "foo",
+      command = new cmd.Delete(
+        deletes = deletes,
+        ordered = true,
+        writeConcern = WriteConcern.Default)))
+  }
+
+  import reactivemongo.api.tests.Pack
+
+  private final class Command(s: Option[Session])
+    extends PackSupport[Pack] with DeleteCommand[Pack] {
+
+    override private[reactivemongo] def session(): Option[Session] = s
+
+    override val pack: Pack = reactivemongo.api.tests.pack
+  }
+}


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #1096 

## Purpose

This is a fix of serialization for `DeleteCmd` because the current implementation is incorrect in some cases described in #1096.

## Background Context

Need `delete.one()` to match the original semantics of `deleteOne()`. 
