### PR TITLE
Publish pekko based ReactiveMongo binaries 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,9 @@ commands:
       scala_version:
         type: string
         default: "2.13.8"
+      actor_module:
+        type: string
+        default: "akka"
       shaded:
         type: boolean
         default: true
@@ -64,6 +67,7 @@ commands:
           command: |
                     export PATH=$PATH:~/sbt/bin
                     export SCALA_VERSION="<< parameters.scala_version >>"
+                    export ACTOR_MODULE="<< parameters.actor_module >>"
                     SHADED="<< parameters.shaded >>"
                     export CI_CATEGORY="<< parameters.category >>"
 
@@ -258,6 +262,9 @@ jobs:
       scala_version:
         type: string
         default: "2.13.8"
+      actor_module:
+        type: string
+        default: "akka"
       shaded:
         type: boolean
         default: true
@@ -276,6 +283,7 @@ jobs:
       - build_n_tests:
           jdk_version: << parameters.jdk_version >>
           scala_version: << parameters.scala_version >>
+          actor_module: << parameters.actor_module >>
           shaded: << parameters.shaded >>
           category: UNIT_TESTS
 
@@ -296,6 +304,9 @@ jobs:
       akka_version:
         type: string
         default: "2.5.23"
+      actor_module:
+        type: string
+        default: "akka"
       shaded:
         type: boolean
         default: true
@@ -316,6 +327,7 @@ jobs:
 
     environment:
       AKKA_VERSION: << parameters.akka_version >>
+      ACTOR_MODULE: << parameters.actor_module >>
       MONGO_PROFILE: << parameters.mongo_profile >>
       MONGO_VER: << parameters.mongo_version >>
       OS_NAME: linux
@@ -333,6 +345,7 @@ jobs:
                     echo "Shaded? << parameters.shaded >>"
                     echo "Compressor: << parameters.compressor>>"
                     echo "Akka: version=$AKKA_VERSION"
+                    echo "Actor module: $ACTOR_MODULE"
 
       - setup_integration:
           mongo_version: $MONGO_VER
@@ -345,6 +358,7 @@ jobs:
           jdk_version: openjdk<< parameters.openjdk_version >>
           scala_version: << parameters.scala_version >>
           shaded: << parameters.shaded >>
+          actor_module: << parameters.actor_module >>
           compressor: << parameters.compressor >>
 
       - collect_test_reports
@@ -414,6 +428,15 @@ workflows:
           jdk_version: openjdk10
           scala_version: 2.12.18
 
+      - unit_test_suite:
+          name: unit_linux_openjdk10_scala212_pekko
+          e:
+            name: openjdk
+            version: 10
+          jdk_version: openjdk10
+          scala_version: 2.12.18
+          actor_module: pekko
+
       - integration_test_suite:
           name: mongo3_openjdk8_scala211_akka23
           openjdk_version: 8
@@ -434,6 +457,12 @@ workflows:
           mongo_version: 5
           mongo_profile: x509
           scala_version: 2.13.8
+
+      - integration_test_suite:
+          name: mongo5_openjdk10_scala213_pekko_x509
+          mongo_version: 5
+          scala_version: 2.13.8
+          actor_module: pekko
 
       - integration_test_suite:
           name: mongo6_openjdk11_scala31_akka26
@@ -512,6 +541,8 @@ workflows:
             - mongo4_openjdk10_scala211_akka25_mutualssl
             - mongo5_openjdk11_scala211_akka25_rs
             - mongo5_openjdk10_scala211_akka25_x509
+            - unit_linux_openjdk10_scala212_pekko
+            - mongo5_openjdk10_scala213_pekko_x509
 
       - trigger_dependent_builds:
           filters:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Then go to the `ReactiveMongo` directory and launch the SBT build console:
 ```
 $ cd ReactiveMongo
 $ sbt
-> +publish-local
+> +publishLocal
 ```
 
 *Running tests:*

--- a/actors-akka/src/main/scala/reactivemongo/actors/actor/package.scala
+++ b/actors-akka/src/main/scala/reactivemongo/actors/actor/package.scala
@@ -1,0 +1,16 @@
+package reactivemongo.actors
+
+package object actor {
+  type ActorSystem = akka.actor.ActorSystem
+  val ActorSystem = akka.actor.ActorSystem
+
+  type ActorRef = akka.actor.ActorRef
+  type Actor = akka.actor.Actor
+  val Actor = akka.actor.Actor
+
+  type Props = akka.actor.Props
+  val Props = akka.actor.Props
+  type Terminated = akka.actor.Terminated
+  type Cancellable = akka.actor.Cancellable
+
+}

--- a/actors-akka/src/main/scala/reactivemongo/actors/actor/package.scala
+++ b/actors-akka/src/main/scala/reactivemongo/actors/actor/package.scala
@@ -12,5 +12,4 @@ package object actor {
   val Props = akka.actor.Props
   type Terminated = akka.actor.Terminated
   type Cancellable = akka.actor.Cancellable
-
 }

--- a/actors-akka/src/main/scala/reactivemongo/actors/pattern/ask/package.scala
+++ b/actors-akka/src/main/scala/reactivemongo/actors/pattern/ask/package.scala
@@ -1,0 +1,14 @@
+package reactivemongo.actors.pattern
+
+import akka.pattern.{
+  AskSupport,
+  FutureTimeoutSupport,
+  GracefulStopSupport,
+  PipeToSupport
+}
+
+package object ask
+    extends PipeToSupport
+    with AskSupport
+    with GracefulStopSupport
+    with FutureTimeoutSupport

--- a/actors-akka/src/main/scala/reactivemongo/actors/pattern/package.scala
+++ b/actors-akka/src/main/scala/reactivemongo/actors/pattern/package.scala
@@ -1,0 +1,5 @@
+package reactivemongo.actors
+
+import akka.pattern.FutureTimeoutSupport
+
+package object pattern extends FutureTimeoutSupport

--- a/actors-akka/src/main/scala/reactivemongo/actors/util/package.scala
+++ b/actors-akka/src/main/scala/reactivemongo/actors/util/package.scala
@@ -1,0 +1,15 @@
+package reactivemongo.actors
+
+import akka.util.{
+  ByteString => PekkoByteString,
+  Timeout => PekkoTimeout
+}
+
+package object util {
+  type Timeout = PekkoTimeout
+  val Timeout = PekkoTimeout
+
+  type ByteString = PekkoByteString
+  val ByteString = PekkoByteString
+
+}

--- a/actors-akka/src/main/scala/reactivemongo/actors/util/package.scala
+++ b/actors-akka/src/main/scala/reactivemongo/actors/util/package.scala
@@ -1,15 +1,9 @@
 package reactivemongo.actors
 
-import akka.util.{
-  ByteString => PekkoByteString,
-  Timeout => PekkoTimeout
-}
-
 package object util {
-  type Timeout = PekkoTimeout
-  val Timeout = PekkoTimeout
+  type Timeout = akka.util.Timeout
+  val Timeout = akka.util.Timeout
 
-  type ByteString = PekkoByteString
-  val ByteString = PekkoByteString
-
+  type ByteString = akka.util.ByteString
+  val ByteString = akka.util.ByteString
 }

--- a/actors-akka/src/test/scala/reactivemongo/actors/testkit/package.scala
+++ b/actors-akka/src/test/scala/reactivemongo/actors/testkit/package.scala
@@ -1,9 +1,8 @@
 package reactivemongo.actors
 
 import akka.actor.Actor
-import akka.testkit.{ TestActorRef => PekkoTestActorRef }
 
 package object testkit {
-  type TestActorRef[T <: Actor] = PekkoTestActorRef[T]
-  val TestActorRef = PekkoTestActorRef
+  type TestActorRef[T <: Actor] = akka.testkit.TestActorRef[T]
+  val TestActorRef = akka.testkit.TestActorRef
 }

--- a/actors-akka/src/test/scala/reactivemongo/actors/testkit/package.scala
+++ b/actors-akka/src/test/scala/reactivemongo/actors/testkit/package.scala
@@ -1,0 +1,9 @@
+package reactivemongo.actors
+
+import akka.actor.Actor
+import akka.testkit.{ TestActorRef => PekkoTestActorRef }
+
+package object testkit {
+  type TestActorRef[T <: Actor] = PekkoTestActorRef[T]
+  val TestActorRef = PekkoTestActorRef
+}

--- a/actors-pekko/src/main/scala/reactivemongo/actors/actor/package.scala
+++ b/actors-pekko/src/main/scala/reactivemongo/actors/actor/package.scala
@@ -1,0 +1,16 @@
+package reactivemongo.actors
+
+package object actor {
+  type ActorSystem = org.apache.pekko.actor.ActorSystem
+  val ActorSystem = org.apache.pekko.actor.ActorSystem
+
+  type ActorRef = org.apache.pekko.actor.ActorRef
+  type Actor = org.apache.pekko.actor.Actor
+  val Actor = org.apache.pekko.actor.Actor
+
+  type Props = org.apache.pekko.actor.Props
+  val Props = org.apache.pekko.actor.Props
+  type Terminated = org.apache.pekko.actor.Terminated
+  type Cancellable = org.apache.pekko.actor.Cancellable
+
+}

--- a/actors-pekko/src/main/scala/reactivemongo/actors/actor/package.scala
+++ b/actors-pekko/src/main/scala/reactivemongo/actors/actor/package.scala
@@ -12,5 +12,4 @@ package object actor {
   val Props = org.apache.pekko.actor.Props
   type Terminated = org.apache.pekko.actor.Terminated
   type Cancellable = org.apache.pekko.actor.Cancellable
-
 }

--- a/actors-pekko/src/main/scala/reactivemongo/actors/pattern/ask/package.scala
+++ b/actors-pekko/src/main/scala/reactivemongo/actors/pattern/ask/package.scala
@@ -1,0 +1,14 @@
+package reactivemongo.actors.pattern
+
+import org.apache.pekko.pattern.{
+  AskSupport,
+  FutureTimeoutSupport,
+  GracefulStopSupport,
+  PipeToSupport
+}
+
+package object ask
+    extends PipeToSupport
+    with AskSupport
+    with GracefulStopSupport
+    with FutureTimeoutSupport

--- a/actors-pekko/src/main/scala/reactivemongo/actors/pattern/package.scala
+++ b/actors-pekko/src/main/scala/reactivemongo/actors/pattern/package.scala
@@ -1,0 +1,5 @@
+package reactivemongo.actors
+
+import org.apache.pekko.pattern.FutureTimeoutSupport
+
+package object pattern extends FutureTimeoutSupport

--- a/actors-pekko/src/main/scala/reactivemongo/actors/util/package.scala
+++ b/actors-pekko/src/main/scala/reactivemongo/actors/util/package.scala
@@ -1,0 +1,15 @@
+package reactivemongo.actors
+
+import org.apache.pekko.util.{
+  ByteString => PekkoByteString,
+  Timeout => PekkoTimeout
+}
+
+package object util {
+  type Timeout = PekkoTimeout
+  val Timeout = PekkoTimeout
+
+  type ByteString = PekkoByteString
+  val ByteString = PekkoByteString
+
+}

--- a/actors-pekko/src/main/scala/reactivemongo/actors/util/package.scala
+++ b/actors-pekko/src/main/scala/reactivemongo/actors/util/package.scala
@@ -1,15 +1,9 @@
 package reactivemongo.actors
 
-import org.apache.pekko.util.{
-  ByteString => PekkoByteString,
-  Timeout => PekkoTimeout
-}
-
 package object util {
-  type Timeout = PekkoTimeout
-  val Timeout = PekkoTimeout
+  type Timeout = org.apache.pekko.util.Timeout
+  val Timeout = org.apache.pekko.util.Timeout
 
-  type ByteString = PekkoByteString
-  val ByteString = PekkoByteString
-
+  type ByteString = org.apache.pekko.util.ByteString
+  val ByteString = org.apache.pekko.util.ByteString
 }

--- a/actors-pekko/src/test/scala/reactivemongo/actors/testkit/package.scala
+++ b/actors-pekko/src/test/scala/reactivemongo/actors/testkit/package.scala
@@ -1,0 +1,9 @@
+package reactivemongo.actors
+
+import org.apache.pekko.actor.Actor
+import org.apache.pekko.testkit.{TestActorRef => PekkoTestActorRef}
+
+package object testkit {
+  type TestActorRef[T <: Actor] = PekkoTestActorRef[T]
+  val TestActorRef = PekkoTestActorRef
+}

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,6 @@
+import sbt.*
+import sbt.Keys.*
+
 lazy val `ReactiveMongo-Core` = project
   .in(file("core"))
   .settings(
@@ -51,14 +54,28 @@ lazy val `ReactiveMongo-Core` = project
     }
   )
 
-lazy val `ReactiveMongo` = new Driver(`ReactiveMongo-Core`).module
+
+lazy val `Actors-Akka` = project.in(file("actors-akka")).settings(
+  libraryDependencies ++= Dependencies.akka.value
+)
+
+lazy val `Actors-Pekko` = project.in(file("actors-pekko")).settings(
+  libraryDependencies ++= Dependencies.pekko.value
+)
+
+lazy val actorModule = Common.actorModule match {
+  case "pekko" => `Actors-Pekko`
+  case "akka" => `Actors-Akka`
+}
+
+lazy val `ReactiveMongo` = new Driver(`ReactiveMongo-Core`, actorModule).module
 
 lazy val `ReactiveMongo-Test` = project
   .in(file("test"))
   .settings(
     description := "ReactiveMongo test helpers"
   )
-  .dependsOn(`ReactiveMongo`)
+  .dependsOn(`ReactiveMongo`).dependsOn()
 
 // ---
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,3 @@
-import sbt.*
-import sbt.Keys.*
-
 lazy val `ReactiveMongo-Core` = project
   .in(file("core"))
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -55,17 +55,17 @@ lazy val `ReactiveMongo-Core` = project
   )
 
 
-lazy val `Actors-Akka` = project.in(file("actors-akka")).settings(
+lazy val `ReactiveMongo-Actors-Akka` = project.in(file("actors-akka")).settings(
   libraryDependencies ++= Dependencies.akka.value
 )
 
-lazy val `Actors-Pekko` = project.in(file("actors-pekko")).settings(
+lazy val `ReactiveMongo-Actors-Pekko` = project.in(file("actors-pekko")).settings(
   libraryDependencies ++= Dependencies.pekko.value
 )
 
 lazy val actorModule = Common.actorModule match {
-  case "pekko" => `Actors-Pekko`
-  case "akka" => `Actors-Akka`
+  case "pekko" => `ReactiveMongo-Actors-Pekko`
+  case "akka" => `ReactiveMongo-Actors-Akka`
 }
 
 lazy val `ReactiveMongo` = new Driver(`ReactiveMongo-Core`, actorModule).module

--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,7 @@ lazy val `ReactiveMongo-Test` = project
   .settings(
     description := "ReactiveMongo test helpers"
   )
-  .dependsOn(`ReactiveMongo`).dependsOn()
+  .dependsOn(`ReactiveMongo`)
 
 // ---
 

--- a/core/src/main/scala-3/silent.scala
+++ b/core/src/main/scala-3/silent.scala
@@ -1,3 +1,4 @@
 package com.github.ghik.silencer
+import annotation.unused
 
-class silent(s: String = "") extends scala.annotation.StaticAnnotation
+class silent(@unused s: String = "") extends scala.annotation.StaticAnnotation

--- a/driver/src/main/scala/api/AsyncDriver.scala
+++ b/driver/src/main/scala/api/AsyncDriver.scala
@@ -18,11 +18,11 @@ import reactivemongo.core.actors.{
   StandardDBSystemWithX509
 }
 import reactivemongo.core.nodeset.Authenticate
-
-import akka.actor.{ Actor, ActorRef, ActorSystem, Props, Terminated }
-import akka.pattern.ask
-import akka.util.Timeout
+import reactivemongo.actors.actor.{ Actor, ActorRef, ActorSystem }
+import reactivemongo.actors.pattern.ask._
+import reactivemongo.actors.util.Timeout
 import com.typesafe.config.Config
+import reactivemongo.actors.actor.{ Props, Terminated }
 
 /**
  * The asynchronous driver (see [[MongoConnection]]).
@@ -38,7 +38,6 @@ import com.typesafe.config.Config
  *
  * @param config a custom configuration (otherwise the default options are used)
  * @param classLoader a classloader used to load the actor system
- *
  * @define parsedURIParam the URI parsed by [[reactivemongo.api.MongoConnection.fromString]]
  * @define connectionNameParam the name for the connection pool
  * @define optionsParam the options for the new connection pool

--- a/driver/src/main/scala/api/AsyncDriver.scala
+++ b/driver/src/main/scala/api/AsyncDriver.scala
@@ -18,11 +18,17 @@ import reactivemongo.core.actors.{
   StandardDBSystemWithX509
 }
 import reactivemongo.core.nodeset.Authenticate
-import reactivemongo.actors.actor.{ Actor, ActorRef, ActorSystem }
+
+import com.typesafe.config.Config
+import reactivemongo.actors.actor.{
+  Actor,
+  ActorRef,
+  ActorSystem,
+  Props,
+  Terminated
+}
 import reactivemongo.actors.pattern.ask._
 import reactivemongo.actors.util.Timeout
-import com.typesafe.config.Config
-import reactivemongo.actors.actor.{ Props, Terminated }
 
 /**
  * The asynchronous driver (see [[MongoConnection]]).
@@ -38,6 +44,7 @@ import reactivemongo.actors.actor.{ Props, Terminated }
  *
  * @param config a custom configuration (otherwise the default options are used)
  * @param classLoader a classloader used to load the actor system
+ *
  * @define parsedURIParam the URI parsed by [[reactivemongo.api.MongoConnection.fromString]]
  * @define connectionNameParam the name for the connection pool
  * @define optionsParam the options for the new connection pool

--- a/driver/src/main/scala/api/Failover.scala
+++ b/driver/src/main/scala/api/Failover.scala
@@ -1,11 +1,12 @@
 package reactivemongo.api
 
-import reactivemongo.actors.pattern.after
-
 import scala.util.{ Failure, Success, Try }
 import scala.util.control.NonFatal
+
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration.{ Duration, FiniteDuration }
+
+import reactivemongo.actors.pattern.after
 import reactivemongo.util.LazyLogger
 
 private[reactivemongo] final class Failover[A](

--- a/driver/src/main/scala/api/Failover.scala
+++ b/driver/src/main/scala/api/Failover.scala
@@ -1,12 +1,11 @@
 package reactivemongo.api
 
+import reactivemongo.actors.pattern.after
+
 import scala.util.{ Failure, Success, Try }
 import scala.util.control.NonFatal
-
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration.{ Duration, FiniteDuration }
-
-import akka.pattern.after
 import reactivemongo.util.LazyLogger
 
 private[reactivemongo] final class Failover[A](

--- a/driver/src/main/scala/api/FoldResponses.scala
+++ b/driver/src/main/scala/api/FoldResponses.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
 
 import reactivemongo.core.protocol.Response
 
-import akka.actor.ActorSystem
+import reactivemongo.actors.actor.ActorSystem
 
 private[api] final class FoldResponses[T](
     failoverStrategy: FailoverStrategy,

--- a/driver/src/main/scala/api/MongoConnection.scala
+++ b/driver/src/main/scala/api/MongoConnection.scala
@@ -41,9 +41,9 @@ import reactivemongo.core.protocol.{ ProtocolMetadata, Response }
 
 import reactivemongo.api.commands.SuccessfulAuthentication
 
-import akka.actor.{ Actor, ActorRef, ActorSystem, Props }
-import akka.pattern.ask
-import akka.util.Timeout
+import reactivemongo.actors.actor.{ Actor, ActorRef, ActorSystem, Props }
+import reactivemongo.actors.pattern.ask._
+import reactivemongo.actors.util.Timeout
 import reactivemongo.util
 
 import util.{ LazyLogger, SRVRecordResolver, TXTResolver }
@@ -275,7 +275,6 @@ final class MongoConnection private[reactivemongo] (
 
       monitor ! check
 
-      import akka.pattern.after
       import actorSystem.dispatcher
 
       def unavailResult = Future.failed[ConnectionState] {

--- a/driver/src/main/scala/api/commands/scram.scala
+++ b/driver/src/main/scala/api/commands/scram.scala
@@ -13,7 +13,7 @@ import reactivemongo.api.{
   SerializationPack
 }
 
-import akka.util.ByteString
+import reactivemongo.actors.util.ByteString
 import reactivemongo.util
 
 // --- MongoDB SCRAM authentication ---

--- a/driver/src/main/scala/core/actors/MongoDBSystem.scala
+++ b/driver/src/main/scala/core/actors/MongoDBSystem.scala
@@ -85,9 +85,9 @@ import reactivemongo.api.commands.{
   UpsertedFactory
 }
 
-import reactivemongo.actors.actor.{ Actor, ActorRef, Cancellable }
 import com.github.ghik.silencer.silent
 import external.reactivemongo.ConnectionListener
+import reactivemongo.actors.actor.{ Actor, ActorRef, Cancellable }
 import reactivemongo.util.{ LazyLogger, SimpleRing }
 
 /** Main actor that processes the requests. */

--- a/driver/src/main/scala/core/actors/MongoDBSystem.scala
+++ b/driver/src/main/scala/core/actors/MongoDBSystem.scala
@@ -85,7 +85,7 @@ import reactivemongo.api.commands.{
   UpsertedFactory
 }
 
-import akka.actor.{ Actor, ActorRef, Cancellable }
+import reactivemongo.actors.actor.{ Actor, ActorRef, Cancellable }
 import com.github.ghik.silencer.silent
 import external.reactivemongo.ConnectionListener
 import reactivemongo.util.{ LazyLogger, SimpleRing }

--- a/driver/src/main/scala/core/akka.scala
+++ b/driver/src/main/scala/core/akka.scala
@@ -5,7 +5,7 @@ import scala.util.{ Failure, Success, Try }
 import scala.concurrent.Future
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 
-import akka.actor.ActorSystem
+import reactivemongo.actors.actor.ActorSystem
 import reactivemongo.util.sameThreadExecutionContext
 
 private[reactivemongo] sealed trait SystemControl

--- a/driver/src/main/scala/core/netty/ChannelFactory.scala
+++ b/driver/src/main/scala/core/netty/ChannelFactory.scala
@@ -32,7 +32,7 @@ import reactivemongo.core.protocol.{
 
 import reactivemongo.api.MongoConnectionOptions
 
-import akka.actor.ActorRef
+import reactivemongo.actors.actor.ActorRef
 import reactivemongo.util.LazyLogger
 
 import ChannelOption.{ CONNECT_TIMEOUT_MILLIS, SO_KEEPALIVE, TCP_NODELAY }

--- a/driver/src/main/scala/core/nodeset/Node.scala
+++ b/driver/src/main/scala/core/nodeset/Node.scala
@@ -9,7 +9,7 @@ import reactivemongo.io.netty.channel.ChannelId
 import reactivemongo.core.netty.ChannelFactory
 import reactivemongo.core.protocol.ProtocolMetadata
 
-import akka.actor.ActorRef
+import reactivemongo.actors.actor.ActorRef
 
 /**
  * @param name the main name of the node

--- a/driver/src/main/scala/core/nodeset/NodeSet.scala
+++ b/driver/src/main/scala/core/nodeset/NodeSet.scala
@@ -13,7 +13,7 @@ import reactivemongo.core.protocol.ProtocolMetadata
 
 import reactivemongo.api.{ Compressor, ReadPreference }
 
-import akka.actor.ActorRef
+import reactivemongo.actors.actor.ActorRef
 
 /**
  * @param name the replicaSet name

--- a/driver/src/main/scala/core/protocol/MongoHandler.scala
+++ b/driver/src/main/scala/core/protocol/MongoHandler.scala
@@ -9,7 +9,7 @@ import reactivemongo.io.netty.handler.timeout.IdleStateEvent
 
 import reactivemongo.core.actors.{ ChannelConnected, ChannelDisconnected }
 
-import akka.actor.ActorRef
+import reactivemongo.actors.actor.ActorRef
 import reactivemongo.util.LazyLogger
 
 private[reactivemongo] class MongoHandler(

--- a/driver/src/main/scala/util/EitherMappableFuture.scala
+++ b/driver/src/main/scala/util/EitherMappableFuture.scala
@@ -22,7 +22,7 @@ import scala.concurrent.{ duration, Future, Promise }
 import duration.Duration
 
 private[reactivemongo] object ExtendedFutures {
-  import akka.actor.ActorSystem
+  import reactivemongo.actors.actor.ActorSystem
 
   // better way to this?
   def delayedFuture(millis: Long, system: ActorSystem): Future[Unit] = {

--- a/driver/src/test/scala/ApiTesting.scala
+++ b/driver/src/test/scala/ApiTesting.scala
@@ -10,7 +10,6 @@ import scala.concurrent.duration.{ FiniteDuration, SECONDS }
 import reactivemongo.io.netty.buffer.{ ByteBuf, Unpooled }
 import reactivemongo.io.netty.channel.{ Channel, ChannelId, DefaultChannelId }
 
-import reactivemongo.actors.pattern.ask._
 import reactivemongo.core.actors
 import reactivemongo.core.errors.DatabaseException
 import reactivemongo.core.netty.ChannelFactory
@@ -33,6 +32,7 @@ import reactivemongo.api.collections.QueryCodecs
 import reactivemongo.api.commands.CommandKind
 
 import reactivemongo.actors.actor.ActorRef
+import reactivemongo.actors.pattern.ask._
 import reactivemongo.actors.util.Timeout
 
 import actors.{

--- a/driver/src/test/scala/ApiTesting.scala
+++ b/driver/src/test/scala/ApiTesting.scala
@@ -10,6 +10,7 @@ import scala.concurrent.duration.{ FiniteDuration, SECONDS }
 import reactivemongo.io.netty.buffer.{ ByteBuf, Unpooled }
 import reactivemongo.io.netty.channel.{ Channel, ChannelId, DefaultChannelId }
 
+import reactivemongo.actors.pattern.ask._
 import reactivemongo.core.actors
 import reactivemongo.core.errors.DatabaseException
 import reactivemongo.core.netty.ChannelFactory
@@ -31,8 +32,8 @@ import reactivemongo.api.bson.collection.BSONSerializationPack
 import reactivemongo.api.collections.QueryCodecs
 import reactivemongo.api.commands.CommandKind
 
-import akka.actor.ActorRef
-import akka.util.Timeout
+import reactivemongo.actors.actor.ActorRef
+import reactivemongo.actors.util.Timeout
 
 import actors.{
   ChannelConnected,
@@ -183,7 +184,6 @@ package object tests { self =>
       options: MongoConnectionOptions,
       mongosystem: ActorRef
     ): Future[Any] = {
-    import akka.pattern.ask
 
     def message = d.addConnectionMsg(name, nodes, options, mongosystem)
     implicit def timeout: Timeout = Timeout(10, SECONDS)

--- a/driver/src/test/scala/ChannelFactorySpec.scala
+++ b/driver/src/test/scala/ChannelFactorySpec.scala
@@ -13,7 +13,7 @@ import org.specs2.concurrent.ExecutionEnv
 import org.specs2.specification.AfterAll
 
 import _root_.tests.{ Common, NettyEmbedder }
-import akka.actor.Actor
+import reactivemongo.actors.actor.Actor
 
 final class ChannelFactorySpec(
     implicit
@@ -41,7 +41,7 @@ final class ChannelFactorySpec(
   }, IsMasterCommand.IsMasterResult
 
   import Common.timeout
-  implicit def actorSys: akka.actor.ActorSystem = Common.driverSystem
+  implicit def actorSys: reactivemongo.actors.actor.ActorSystem = Common.driverSystem
 
   val factory = channelFactory("sup-1", "con-2", Common.DefaultOptions)
 
@@ -79,7 +79,7 @@ final class ChannelFactorySpec(
         }
       }
 
-      val actorRef = akka.testkit.TestActorRef(actor, "test1")
+      val actorRef = reactivemongo.actors.testkit.TestActorRef(actor, "test1")
 
       val req = isMasterRequest()
       val reqBytes: Array[Byte] = {
@@ -137,7 +137,7 @@ final class ChannelFactorySpec(
           val receive: Receive = { case _ => () }
         }
 
-        val actorRef = akka.testkit.TestActorRef(actor, "test3")
+        val actorRef = reactivemongo.actors.testkit.TestActorRef(actor, "test3")
 
         createChannel(factory, actorRef, "foo", 27017, 0).aka(
           "channel"
@@ -186,7 +186,7 @@ final class ChannelFactorySpec(
         }
       }
 
-      val actorRef = akka.testkit.TestActorRef(actor, "test2")
+      val actorRef = reactivemongo.actors.testkit.TestActorRef(actor, "test2")
 
       createChannel(
         factory,

--- a/driver/src/test/scala/DriverSpec.scala
+++ b/driver/src/test/scala/DriverSpec.scala
@@ -25,7 +25,7 @@ import reactivemongo.api.commands.{
 
 import org.specs2.concurrent.ExecutionEnv
 
-import akka.actor.{ Actor, ActorRef, ActorSystem, Props }
+import reactivemongo.actors.actor.{ Actor, ActorRef, ActorSystem, Props }
 
 final class DriverSpec(
     implicit
@@ -476,7 +476,7 @@ final class DriverSpec(
     }
 
     val receive: Receive = {
-      case sys: akka.actor.ActorRef => {
+      case sys: reactivemongo.actors.actor.ActorRef => {
         // Manually register this as connection/system monitor
         sys ! reactivemongo.api.tests.RegisterMonitor
       }

--- a/driver/src/test/scala/MonitorSpec.scala
+++ b/driver/src/test/scala/MonitorSpec.scala
@@ -27,8 +27,8 @@ import org.specs2.concurrent.ExecutionEnv
 import org.specs2.execute.Result
 
 import _root_.tests.Common
-import akka.actor.Actor
-import akka.testkit.TestActorRef
+import reactivemongo.actors.actor.Actor
+import reactivemongo.actors.testkit.TestActorRef
 
 final class MonitorSpec(
     implicit
@@ -487,7 +487,7 @@ final class MonitorSpec(
     val supervisorName = s"monitorspec-sup-${System identityHashCode ee}"
     val poolName = s"monitorspec-con-${System identityHashCode f}"
 
-    implicit def sys: akka.actor.ActorSystem =
+    implicit def sys: reactivemongo.actors.actor.ActorSystem =
       reactivemongo.api.tests.system(drv)
 
     lazy val mongosystem = TestActorRef[StandardDBSystem](

--- a/driver/src/test/scala/NodeSetSpec.scala
+++ b/driver/src/test/scala/NodeSetSpec.scala
@@ -1,9 +1,9 @@
 package reactivemongo
 
-import reactivemongo.actors.pattern.ask._
-
 import scala.collection.immutable.ListSet
+
 import scala.concurrent.{ Await, Future }
+
 import reactivemongo.core.actors.{
   PrimaryAvailable,
   PrimaryUnavailable,
@@ -21,15 +21,19 @@ import reactivemongo.core.nodeset.{
   PingInfo
 }
 import reactivemongo.core.protocol.ProtocolMetadata
+
 import reactivemongo.api.{
   AsyncDriver,
   MongoConnection,
   MongoConnectionOptions,
   ReadPreference
 }
+
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.matcher.MatchResult
+
 import reactivemongo.actors.actor.ActorRef
+import reactivemongo.actors.pattern.ask._
 import reactivemongo.actors.testkit.TestActorRef
 
 final class NodeSetSpec(

--- a/driver/src/test/scala/NodeSetSpec.scala
+++ b/driver/src/test/scala/NodeSetSpec.scala
@@ -1,10 +1,9 @@
 package reactivemongo
 
+import reactivemongo.actors.pattern.ask._
+
 import scala.collection.immutable.ListSet
-
 import scala.concurrent.{ Await, Future }
-import scala.math.Ordering
-
 import reactivemongo.core.actors.{
   PrimaryAvailable,
   PrimaryUnavailable,
@@ -22,19 +21,16 @@ import reactivemongo.core.nodeset.{
   PingInfo
 }
 import reactivemongo.core.protocol.ProtocolMetadata
-
 import reactivemongo.api.{
   AsyncDriver,
   MongoConnection,
   MongoConnectionOptions,
   ReadPreference
 }
-
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.matcher.MatchResult
-
-import akka.actor.ActorRef
-import akka.testkit.TestActorRef
+import reactivemongo.actors.actor.ActorRef
+import reactivemongo.actors.testkit.TestActorRef
 
 final class NodeSetSpec(
     implicit
@@ -204,8 +200,7 @@ final class NodeSetSpec(
         before = sys.underlyingActor._nodeSet.nodes.map(_.name)
 
         import scala.concurrent.duration._
-        import akka.pattern.ask
-        import akka.util.Timeout
+        import reactivemongo.actors.util.Timeout
 
         implicit def timeout: Timeout = Timeout(3.seconds)
 
@@ -333,7 +328,7 @@ final class NodeSetSpec(
     val supervisorName = s"withConAndSys-sup-${System identityHashCode ee}"
     val poolName = s"withConAndSys-con-${System identityHashCode f}"
 
-    @inline implicit def sys: akka.actor.ActorSystem =
+    @inline implicit def sys: reactivemongo.actors.actor.ActorSystem =
       reactivemongo.api.tests.system(drv)
 
     val auths = Seq(Authenticate(Common.commonDb, "test", Some("password")))

--- a/driver/src/test/scala/UnresponsiveSecondaryTest.scala
+++ b/driver/src/test/scala/UnresponsiveSecondaryTest.scala
@@ -25,8 +25,8 @@ import reactivemongo.api.bson.collection.BSONSerializationPack
 import org.specs2.matcher.MatchResult
 
 import _root_.tests.{ Common, NettyEmbedder }
-import akka.actor.ActorRef
-import akka.testkit.TestActorRef
+import reactivemongo.actors.actor.ActorRef
+import reactivemongo.actors.testkit.TestActorRef
 
 trait UnresponsiveSecondaryTest { parent: NodeSetSpec =>
   import reactivemongo.api.tests._

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -37,7 +37,7 @@ object Common extends AutoPlugin {
   val scala211 = "2.11.12"
   val scala212 = "2.12.18"
   val scala213 = "2.13.8"
-  val scala31 = "3.2.2" // CI uses 3.1.2-RC1-bin-20220113-8d28d94-NIGHTLY"
+  val scala3 = "3.2.2" // CI uses 3.1.2-RC1-bin-20220113-8d28d94-NIGHTLY"
 
   def majorVersion = {
     val Major = """([0-9]+)\.([0-9]+)\..*""".r
@@ -58,7 +58,7 @@ object Common extends AutoPlugin {
   )
 
   lazy val scalaVersions: Seq[String] = {
-    if (actorModule == "akka") Seq(scala211, scala212, scala213, scala31)
+    if (actorModule == "akka") Seq(scala211, scala212, scala213, scala3)
     else Seq(scala212, scala213)
   }
 

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -11,9 +11,6 @@ object Common extends AutoPlugin {
   override def requires = JvmPlugin
 
   lazy val actorModule = sys.env.getOrElse("ACTOR_MODULE", "akka")
-    case Some("pekko") => "pekko"
-    case _             => "akka"
-  }
 
   val baseSettings = Seq(
     organization := "org.reactivemongo",

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -10,7 +10,7 @@ object Common extends AutoPlugin {
   override def trigger = allRequirements
   override def requires = JvmPlugin
 
-  lazy val actorModule = sys.env.get("ACTOR_MODULE") match {
+  lazy val actorModule = sys.env.getOrElse("ACTOR_MODULE", "akka")
     case Some("pekko") => "pekko"
     case _             => "akka"
   }

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -10,6 +10,11 @@ object Common extends AutoPlugin {
   override def trigger = allRequirements
   override def requires = JvmPlugin
 
+  lazy val actorModule = sys.env.get("ACTOR_MODULE") match {
+    case Some("pekko") => "pekko"
+    case _             => "akka"
+  }
+
   val baseSettings = Seq(
     organization := "org.reactivemongo",
     resolvers += Resolver.typesafeRepo("releases"),
@@ -30,6 +35,7 @@ object Common extends AutoPlugin {
   private val java8 = scala.util.Properties.isJavaAtLeast("1.8")
 
   val scala211 = "2.11.12"
+  val scala212 = "2.12.18"
   val scala213 = "2.13.8"
   val scala31 = "3.2.2" // CI uses 3.1.2-RC1-bin-20220113-8d28d94-NIGHTLY"
 
@@ -51,15 +57,15 @@ object Common extends AutoPlugin {
     "Use ReactiveMongo-Shaded (see system property 'reactivemongo.shaded')"
   )
 
+  lazy val scalaVersions: Seq[String] = {
+    if (actorModule == "akka") Seq(scala211, scala212, scala213, scala31)
+    else Seq(scala212, scala213)
+  }
+
   override def projectSettings =
     Defaults.coreDefaultSettings ++ baseSettings ++ Compiler.settings ++ Seq(
-      scalaVersion := "2.12.18",
-      crossScalaVersions := Seq(
-        scala211,
-        scalaVersion.value,
-        scala213,
-        scala31
-      ),
+      scalaVersion := scala212,
+      crossScalaVersions := scalaVersions,
       crossVersion := CrossVersion.binary,
       useShaded := sys.env.get("REACTIVEMONGO_SHADED").fold(true)(_.toBoolean),
       target := {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,6 +33,7 @@ object Dependencies {
 
   val pekko = Def.setting[Seq[ModuleID]] {
     val ver = "1.0.1"
+
     Seq(
       "org.apache.pekko" %% "pekko-actor" % ver,
       "org.apache.pekko" %% "pekko-testkit" % ver % Test,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,6 +31,15 @@ object Dependencies {
     )
   }
 
+  val pekko = Def.setting[Seq[ModuleID]] {
+    val ver = "1.0.1"
+    Seq(
+      "org.apache.pekko" %% "pekko-actor" % ver,
+      "org.apache.pekko" %% "pekko-testkit" % ver % Test,
+      "org.apache.pekko" %% "pekko-slf4j" % ver % Test
+    )
+  }
+
   val specsVer = Def.setting[String] {
     if (scalaBinaryVersion.value == "2.11") {
       "4.10.6"

--- a/project/Driver.scala
+++ b/project/Driver.scala
@@ -11,9 +11,11 @@ import sbt.Keys._
 
 import com.typesafe.tools.mima.plugin.MimaKeys.mimaBinaryIssueFilters
 
-final class Driver(core: Project) {
+final class Driver(core: Project, actorModule: Project) {
   import Dependencies._
   import XmlUtil._
+
+  println(s"Using actor module ${actorModule.id}")
 
   lazy val module = Project("ReactiveMongo", file("driver"))
     .settings(
@@ -71,7 +73,7 @@ final class Driver(core: Project) {
             Seq.empty[ModuleID]
           }
         },
-        libraryDependencies ++= akka.value ++ Seq(
+        libraryDependencies ++= Seq(
           ("dnsjava" % "dnsjava" % "3.5.2").exclude("org.slf4j", "*"),
           commonsCodec,
           specs.value,
@@ -150,6 +152,7 @@ final class Driver(core: Project) {
       }
     }
     .dependsOn(core)
+    .dependsOn(actorModule % "compile->compile;test->test")
 
   // ---
 

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -50,7 +50,7 @@ object Publish {
     Test / publishArtifact := false,
     publishTo := Some(repoUrl).map(repoName at _),
     artifactName := { (sv: ScalaVersion, module: ModuleID, artifact: Artifact) =>
-      artifact.name + modulePostfix + "-" + module.revision + "." + artifact.extension
+      s"${artifact.name}$modulePostfix-${module.revision}.${artifact.extension}"
     },
     credentials += Credentials(
       repoName,

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -35,12 +35,23 @@ object Publish {
     mimaBinaryIssueFilters ++= Seq(missingMethodInOld)
   )
 
+  val modulePostfix = {
+    Common.actorModule match {
+      case "pekko" => "-pekko"
+      case _       => ""
+    }
+
+  }
+
   val siteUrl = "http://reactivemongo.org"
 
   lazy val settings = Seq(
     publishMavenStyle := true,
     Test / publishArtifact := false,
     publishTo := Some(repoUrl).map(repoName at _),
+    artifactName := { (sv: ScalaVersion, module: ModuleID, artifact: Artifact) =>
+      artifact.name + modulePostfix + "-" + module.revision + "." + artifact.extension
+    },
     credentials += Credentials(
       repoName,
       env("PUBLISH_REPO_ID"),


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #1244

## Purpose

Create a pekko based ReactiveMongo distribution for those who want to adopt Pekko.

## Background Context

Implementation details
 - Introduce neutral aliases for Akka actor dependencies to minimize duplication
 - Pulls in akka or pekko dependencies based on a build parameter

Features
- Publishes pekko variants of all modules
- Adds pekko based permutations to integration test matrix
- Does not build scala 3 version for pekko yet, because Pekko needs Scala 3.3.0 or higher 

Some integration tests are failing intermittently with timeouts, but it doesn't seem related to the changes.

Related PR on documentation repo https://github.com/ReactiveMongo/reactivemongo-site/pull/316