### PR TITLE
 Feature/scala 3.3.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -443,8 +443,8 @@ workflows:
           actor_module: pekko
 
       - integration_test_suite:
-          name: mongo6_openjdk11_scala31_akka26
-          scala_version: '3.2.2'
+          name: mongo6_openjdk11_scala3_akka26
+          scala_version: '3.3.3'
           akka_version: 2.6.20
           openjdk_version: 11
           mongo_version: 6
@@ -461,8 +461,8 @@ workflows:
           mongo_profile: mutual-ssl
 
       - integration_test_suite:
-          name: mongo6_openjdk11_scala31_akka26_rs
-          scala_version: '3.2.2'
+          name: mongo6_openjdk11_scala3_akka26_rs
+          scala_version: '3.3.3'
           akka_version: 2.6.20
           mongo_version: 6
           mongo_profile: rs
@@ -510,10 +510,10 @@ workflows:
             - mongo3_openjdk8_scala211_akka23
             - mongo4_openjdk8_scala213_akka25_rs
             - mongo5_openjdk10_scala213_akka25_x509
-            - mongo6_openjdk11_scala31_akka26
+            - mongo6_openjdk11_scala3_akka26
             - mongo7_openjdk10_scala212_akka25_invalidssl
             - mongo5_openjdk10_scala212_akka25_mutualssl
-            - mongo6_openjdk11_scala31_akka26_rs
+            - mongo6_openjdk11_scala3_akka26_rs
             - mongo5_openjdk10_scala212_akka25_x509
             - mongo5_openjdk10_scala211_akka25
             - mongo4_openjdk10_scala211_akka25_mutualssl

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -34,7 +34,7 @@ object Common extends AutoPlugin {
   val scala211 = "2.11.12"
   val scala212 = "2.12.18"
   val scala213 = "2.13.8"
-  val scala3 = "3.2.2" // CI uses 3.1.2-RC1-bin-20220113-8d28d94-NIGHTLY"
+  val scala3 = "3.3.3"
 
   def majorVersion = {
     val Major = """([0-9]+)\.([0-9]+)\..*""".r

--- a/project/Compiler.scala
+++ b/project/Compiler.scala
@@ -87,7 +87,7 @@ object Compiler {
           "-Wunused"
         )
       } else {
-        Seq("-Wunused:all", "-language:implicitConversions")
+        Seq("-Wunused:nowarn", "-language:implicitConversions")
       }
     },
     Compile / console / scalacOptions ~= {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [ ] Have you added tests for any changed functionality?

## Fixes

Fixes #1250 and https://github.com/scala/scala3/issues/18555

## Purpose

Fix or get up-to-date feedback from the CI failures.

## Background Context

* Updating to 3.3.x was attempted in #1251. CI output is not available anymore.
* Updating to 3.3.3 was attempted in #1291. This failed because the bot did not update the `scala_version` in `.circleci/config.yml`.
* ~I did not manage to get the compilation failure shown in the issue when running locally (it might be fixed). I did remove the `-XX:+CMSClassUnloadingEnabled` from `.jvmopts` as the JVM I used did not support it.~ Now I managed to reproduce it.

## References

* https://github.com/scala/scala3/issues/18555
