### PR TITLE
Copy the channelIdHint for the next request. Fixes #1185

### DIFF
--- a/driver/src/main/scala/api/DefaultCursor.scala
+++ b/driver/src/main/scala/api/DefaultCursor.scala
@@ -585,8 +585,7 @@ private[reactivemongo] object DefaultCursor {
         logger.trace(s"Asking for the next batch of $ntr documents on cursor #${reply.cursorID}, after ${nextOffset}: ${reqMaker.op}")
 
         def req = new ExpectingResponse(
-          requestMaker =
-            reqMaker.copyWithChannelIdHint(Some(response.info.channelId)),
+          requestMaker = reqMaker.withChannelIdHint(response.info.channelId),
           pinnedNode = transaction.flatMap(_.pinnedNode)
         )
 

--- a/driver/src/main/scala/api/DefaultCursor.scala
+++ b/driver/src/main/scala/api/DefaultCursor.scala
@@ -585,7 +585,8 @@ private[reactivemongo] object DefaultCursor {
         logger.trace(s"Asking for the next batch of $ntr documents on cursor #${reply.cursorID}, after ${nextOffset}: ${reqMaker.op}")
 
         def req = new ExpectingResponse(
-          requestMaker = reqMaker,
+          requestMaker =
+            reqMaker.copyWithChannelIdHint(Some(response.info.channelId)),
           pinnedNode = transaction.flatMap(_.pinnedNode)
         )
 

--- a/driver/src/main/scala/core/protocol/RequestMaker.scala
+++ b/driver/src/main/scala/core/protocol/RequestMaker.scala
@@ -37,18 +37,15 @@ private[reactivemongo] final class RequestMaker(
     current.result()
   }
 
-  def copyWithChannelIdHint(
-      newChannelIdHint: Option[ChannelId]
-    ): RequestMaker = {
+  @inline def withChannelIdHint(channelId: ChannelId): RequestMaker =
     new RequestMaker(
       kind,
       op,
       payload,
       readPreference,
-      newChannelIdHint,
+      Some(channelId),
       callerSTE
     )
-  }
 
   @inline def apply(requestID: Int): Request =
     Request(

--- a/driver/src/main/scala/core/protocol/RequestMaker.scala
+++ b/driver/src/main/scala/core/protocol/RequestMaker.scala
@@ -37,6 +37,19 @@ private[reactivemongo] final class RequestMaker(
     current.result()
   }
 
+  def copyWithChannelIdHint(
+      newChannelIdHint: Option[ChannelId]
+    ): RequestMaker = {
+    new RequestMaker(
+      kind,
+      op,
+      payload,
+      readPreference,
+      newChannelIdHint,
+      callerSTE
+    )
+  }
+
   @inline def apply(requestID: Int): Request =
     Request(
       kind,


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [ ] Have you added tests for any changed functionality?

## Fixes

Fixes #1185 

## Purpose

This PR aims to fix the 1185 issue.

## Background Context

In order to keep the change minimal i decided to create a specific copy method.
Altering the signature of the `getMoreOpCmd` to give the `channelIdHint` or switching `RequestMaker` to a case class is also possible.

Feel free to change the implementation or give any feedback on my code.


About the tests, adding a secondary node to the replicaset seemed like a comprehensive change and altered the pipeline quite a bit so i did not feel confident to change this. 

The [minimal reproduction program](https://github.com/ornicar/rm-issue) written by @ornicar can validate that the issue is fixed.

## References

Are there any relevant issues / PRs / mailing lists discussions?
