### PR TITLE
Fix issue 1309 Timed out cursors

### DIFF
--- a/driver/src/main/scala/api/collections/QueryBuilderFactory.scala
+++ b/driver/src/main/scala/api/collections/QueryBuilderFactory.scala
@@ -596,7 +596,7 @@ trait QueryBuilderFactory[P <: SerializationPack] extends HintFactory[P] {
         reader: pack.Reader[T],
         ec: ExecutionContext
       ): Future[Option[T]] =
-      copy(batchSize = 1).defaultCursor(readPreference)(reader).headOption
+      copy(batchSize = 1, singleBatch = true).defaultCursor(readPreference)(reader).headOption
 
     /**
      * $requireOneFunction


### PR DESCRIPTION
- set the option singleBatch to true when selecting just a single document with the function one() of the class QueryBuilder

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [ ] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [ ] Have you added tests for any changed functionality?

## Fixes

Fixes #1309

## Purpose

The option singleBatch is set to true when selecting a single document with the function one() of the class QueryBuilder

## Background Context

The reactive mongo cursor API does not provide any option to close a cursor. In order to avoid open cursors when selecting just a single document the appropriate options have to be set along with the find operation so that the Mongo DB server can close the cursor a soon as the application does not need the cursor anymore.

## References

Are there any relevant issues / PRs / mailing lists discussions?
